### PR TITLE
UT's for Signaling

### DIFF
--- a/source/signaling_api.c
+++ b/source/signaling_api.c
@@ -42,10 +42,12 @@ static SignalingResult_t InterpretSnprintfReturnValue( int snprintfRetVal,
 {
     SignalingResult_t result;
 
+    /* LCOV_EXCL_START */
     if( snprintfRetVal < 0 )
     {
         result = SIGNALING_RESULT_SNPRINTF_ERROR;
     }
+    /* LCOV_EXCL_STOP  */
     else if( ( size_t ) snprintfRetVal >= bufferLength )
     {
         result = SIGNALING_RESULT_OUT_OF_MEMORY;
@@ -124,12 +126,6 @@ static SignalingResult_t ParseIceServerList( const char * pIceServerListBuffer,
     size_t iceServerStart = 0, iceServerNext = 0;
     char ttlSecondsBuffer[ SIGNALING_ICE_SERVER_TTL_SECONDS_BUFFER_MAX ] = { 0 };
     size_t iceServerCount = 0;
-
-    if( ( pIceServerListBuffer == NULL ) ||
-        ( pIceServers == NULL ) )
-    {
-        result = SIGNALING_RESULT_BAD_PARAM;
-    }
 
     while( ( result == SIGNALING_RESULT_OK ) &&
            ( iceServerCount < *pNumIceServers ) )
@@ -1237,7 +1233,7 @@ SignalingResult_t Signaling_ConstructJoinStorageSessionRequest( SignalingChannel
             snprintfRetVal = snprintf( pRequestBuffer->pBody,
                                        pRequestBuffer->bodyLength,
                                        "{"
-                                            "\"channelArn\":\"%.*s\""
+                                            "\"ChannelARN\":\"%.*s\""
                                        "}",
                                        ( int ) pJoinStorageSessionRequestInfo->channelArn.channelArnLength,
                                        pJoinStorageSessionRequestInfo->channelArn.pChannelArn );
@@ -1247,8 +1243,8 @@ SignalingResult_t Signaling_ConstructJoinStorageSessionRequest( SignalingChannel
             snprintfRetVal = snprintf( pRequestBuffer->pBody,
                                        pRequestBuffer->bodyLength,
                                        "{"
-                                            "\"channelArn\":\"%.*s\","
-                                            "\"clientId\":\"%.*s\""
+                                            "\"ChannelARN\":\"%.*s\","
+                                            "\"ClientId\":\"%.*s\""
                                        "}",
                                        ( int ) pJoinStorageSessionRequestInfo->channelArn.channelArnLength,
                                        pJoinStorageSessionRequestInfo->channelArn.pChannelArn,
@@ -1424,7 +1420,7 @@ SignalingResult_t Signaling_ConstructWssMessage( WssSendMessage_t * pWssSendMess
                                    "{"
                                         "\"action\":\"%s\","
                                         "\"RecipientClientId\":\"%.*s\","
-                                        "\"MessagePayload\": \"%.*s\"",
+                                        "\"MessagePayload\":\"%.*s\"",
                                    GetStringFromMessageType( pWssSendMessage->messageType ),
                                    ( int ) pWssSendMessage->recipientClientIdLength,
                                    pWssSendMessage->pRecipientClientId,
@@ -1503,14 +1499,15 @@ SignalingResult_t Signaling_ParseWssRecvMessage( const char * pMessage,
         result = SIGNALING_RESULT_BAD_PARAM;
     }
 
-    /* Exclude null terminator in messageLength. */
-    if( pMessage[ messageLength - 1 ] == '\0' )
-    {
-        messageLength--;
-    }
-
     if( result == SIGNALING_RESULT_OK )
     {
+        /* Exclude null terminator in messageLength. */
+        
+        if( pMessage[ messageLength - 1 ] == '\0' )
+        {
+            messageLength--;
+        }
+
         jsonResult = JSON_Validate( pMessage, messageLength );
 
         if( jsonResult != JSONSuccess )

--- a/source/signaling_api.c
+++ b/source/signaling_api.c
@@ -793,6 +793,10 @@ SignalingResult_t Signaling_ParseCreateSignalingChannelResponse( const char * pM
                 pChannelArn->pChannelArn = pair.value;
                 pChannelArn->channelArnLength = pair.valueLength;
             }
+            else
+            {
+                result = SIGNALING_RESULT_UNEXPECTED_RESPONSE;
+            }
         }
         else
         {

--- a/source/signaling_api.c
+++ b/source/signaling_api.c
@@ -1233,7 +1233,7 @@ SignalingResult_t Signaling_ConstructJoinStorageSessionRequest( SignalingChannel
             snprintfRetVal = snprintf( pRequestBuffer->pBody,
                                        pRequestBuffer->bodyLength,
                                        "{"
-                                            "\"ChannelARN\":\"%.*s\""
+                                            "\"channelArn\":\"%.*s\""
                                        "}",
                                        ( int ) pJoinStorageSessionRequestInfo->channelArn.channelArnLength,
                                        pJoinStorageSessionRequestInfo->channelArn.pChannelArn );
@@ -1243,8 +1243,8 @@ SignalingResult_t Signaling_ConstructJoinStorageSessionRequest( SignalingChannel
             snprintfRetVal = snprintf( pRequestBuffer->pBody,
                                        pRequestBuffer->bodyLength,
                                        "{"
-                                            "\"ChannelARN\":\"%.*s\","
-                                            "\"ClientId\":\"%.*s\""
+                                            "\"channelArn\":\"%.*s\","
+                                            "\"clientId\":\"%.*s\""
                                        "}",
                                        ( int ) pJoinStorageSessionRequestInfo->channelArn.channelArnLength,
                                        pJoinStorageSessionRequestInfo->channelArn.pChannelArn,
@@ -1502,10 +1502,12 @@ SignalingResult_t Signaling_ParseWssRecvMessage( const char * pMessage,
     if( result == SIGNALING_RESULT_OK )
     {
         /* Exclude null terminator in messageLength. */
-        
-        if( pMessage[ messageLength - 1 ] == '\0' )
+        if(messageLength > 0 )
         {
-            messageLength--;
+            if( pMessage[ messageLength - 1 ] == '\0' )
+                {
+                    messageLength--;
+                }      
         }
 
         jsonResult = JSON_Validate( pMessage, messageLength );

--- a/test/unit-test/signaling_api/signaling_api_utest.c
+++ b/test/unit-test/signaling_api/signaling_api_utest.c
@@ -2954,7 +2954,7 @@ void test_signaling_ConstructJoinStorageSessionRequest_Master( void )
     SignalingResult_t result;
     const char * pExpectedUrl = "webrtc://example.com/joinStorageSession";
     const char * pExpectedBody = "{"
-                                    "\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\""
+                                    "\"channelArn\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\""
                                   "}";
 
     webrtcEndpoint.pEndpoint = "webrtc://example.com";
@@ -3001,8 +3001,8 @@ void test_signaling_ConstructJoinStorageSessionRequest_Viewer( void )
     SignalingResult_t result;
     const char * pExpectedUrl = "webrtc://example.com/joinStorageSession";
     const char * pExpectedBody = "{"
-                                    "\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\","
-                                    "\"ClientId\":\"TestClient\""
+                                    "\"channelArn\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\","
+                                    "\"clientId\":\"TestClient\""
                                   "}";
 
     webrtcEndpoint.pEndpoint = "webrtc://example.com";
@@ -4213,6 +4213,25 @@ void test_signaling_ParseWssRecvMessage_InvalidStatusResponse( void )
                                             messageLength, &( wssRecvMessage ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_STATUS_RESPONSE,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Web-Socket Receive Message functionality.
+ */
+void test_signaling_ParseWssRecvMessage_Empty( void )
+{
+    SignalingResult_t result;
+    WssRecvMessage_t wssRecvMessage = { 0 };
+    const char *message  = "";
+    size_t messageLength = 0;
+
+    result = Signaling_ParseWssRecvMessage( message,
+                                            messageLength, &( wssRecvMessage ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
                        result );
 }
 

--- a/test/unit-test/signaling_api/signaling_api_utest.c
+++ b/test/unit-test/signaling_api/signaling_api_utest.c
@@ -48,7 +48,7 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_BadParams( void )
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
-  
+
     result = Signaling_ConstructDescribeSignalingChannelRequest( &( awsRegion ),
                                                                  NULL,
                                                                  &( requestBuffer ) );
@@ -94,9 +94,13 @@ void test_signaling_ConstructDescribeSignalingChannelRequest( void )
     SignalingAwsRegion_t awsRegion = { 0 };
     SignalingChannelName_t channelName = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
     char urlBuffer[ 200 ];
     char bodyBuffer[ 100 ];
-    SignalingResult_t result;
+    const char * pExpectedUrl = "https://kinesisvideo.us-east-1.amazonaws.com/describeSignalingChannel";
+    const char * pExpectedBody = "{"
+                                    "\"ChannelName\":\"Test-Channel\""
+                                  "}";
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -104,18 +108,25 @@ void test_signaling_ConstructDescribeSignalingChannelRequest( void )
     channelName.pChannelName = "Test-Channel";
     channelName.channelNameLength = strlen( channelName.pChannelName );
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDescribeSignalingChannelRequest( &( awsRegion ),
-                                                                 &( channelName ), &( requestBuffer ) );
+                                                                 &( channelName ),
+                                                                 &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL_STRING( "https://kinesisvideo.us-east-1.amazonaws.com/describeSignalingChannel", requestBuffer.pUrl );
-    TEST_ASSERT_EQUAL_STRING( "{\"ChannelName\":\"Test-Channel\"}", requestBuffer.pBody );
+    TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
+                       requestBuffer.urlLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
+                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
+                       requestBuffer.bodyLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
+                              requestBuffer.pBody );
 }
 
 /*-----------------------------------------------------------*/
@@ -131,6 +142,10 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_SmallLengthRegion( 
     char urlBuffer[ 200 ];
     char bodyBuffer[ 100 ];
     SignalingResult_t result;
+    const char * pExpectedUrl = "https://kinesisvideo.ca.amazonaws.com/describeSignalingChannel";
+    const char * pExpectedBody = "{"
+                                    "\"ChannelName\":\"Test-Channel-China\""
+                                  "}";
 
     awsRegion.pAwsRegion = "ca"; /* The Region Length is < 3 */
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -138,9 +153,9 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_SmallLengthRegion( 
     channelName.pChannelName = "Test-Channel-China";
     channelName.channelNameLength = strlen( channelName.pChannelName );
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDescribeSignalingChannelRequest( &( awsRegion ),
@@ -148,8 +163,14 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_SmallLengthRegion( 
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL_STRING( "https://kinesisvideo.ca.amazonaws.com/describeSignalingChannel", requestBuffer.pUrl );
-    TEST_ASSERT_EQUAL_STRING( "{\"ChannelName\":\"Test-Channel-China\"}", requestBuffer.pBody );
+    TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
+                       requestBuffer.urlLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
+                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
+                       requestBuffer.bodyLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
+                              requestBuffer.pBody );
 }
 
 /*-----------------------------------------------------------*/
@@ -165,6 +186,10 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_ChinaRegion( void )
     char urlBuffer[ 200 ];
     char bodyBuffer[ 100 ];
     SignalingResult_t result;
+    const char * pExpectedUrl = "https://kinesisvideo.cn-east-1.amazonaws.com.cn/describeSignalingChannel";
+    const char * pExpectedBody = "{"
+                                    "\"ChannelName\":\"Test-Channel-China\""
+                                  "}";
 
     awsRegion.pAwsRegion = "cn-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -172,9 +197,9 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_ChinaRegion( void )
     channelName.pChannelName = "Test-Channel-China";
     channelName.channelNameLength = strlen( channelName.pChannelName );
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDescribeSignalingChannelRequest( &( awsRegion ),
@@ -182,8 +207,14 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_ChinaRegion( void )
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL_STRING( "https://kinesisvideo.cn-east-1.amazonaws.com.cn/describeSignalingChannel", requestBuffer.pUrl );
-    TEST_ASSERT_EQUAL_STRING( "{\"ChannelName\":\"Test-Channel-China\"}", requestBuffer.pBody );
+    TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
+                       requestBuffer.urlLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
+                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
+                       requestBuffer.bodyLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
+                              requestBuffer.pBody );
 }
 
 /*-----------------------------------------------------------*/
@@ -206,9 +237,9 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_URLOutofMemory( voi
     channelName.pChannelName = "Test-Channel";
     channelName.channelNameLength = strlen( channelName.pChannelName );
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDescribeSignalingChannelRequest( &( awsRegion ),
@@ -238,9 +269,9 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_BodyOutofMemory( vo
     channelName.pChannelName = "Test-Channel";
     channelName.channelNameLength = strlen( channelName.pChannelName );
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDescribeSignalingChannelRequest( &( awsRegion ),
@@ -257,8 +288,8 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_BodyOutofMemory( vo
  */
 void test_signaling_ParseDescribeSignalingChannelResponse_BadParams( void )
 {
-    const char message;
-    size_t messageLength = sizeof( message );
+    const char * message = "Input Message";
+    size_t messageLength = strlen( message );
     SignalingChannelInfo_t channelInfo;
     SignalingResult_t result;
 
@@ -268,7 +299,7 @@ void test_signaling_ParseDescribeSignalingChannelResponse_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    result = Signaling_ParseDescribeSignalingChannelResponse( &( message ),
+    result = Signaling_ParseDescribeSignalingChannelResponse( message ,
                                                               messageLength, NULL );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
@@ -297,7 +328,7 @@ void test_signaling_ParseDescribeSignalingChannelResponse_InvalidJson( void )
 
     const char *message2 = "{"
         "\"ChannelInfo\": {"
-            "\"SingleMasterConfiguration\": \"InvalidValue\""
+            "\"SingleMasterConfiguration\": {\"MessbkpTtlSeconds\": 60}"        /* The SingleMasterConfiguration Contains Invalid Value */
         "}"
     "}";
     size_t messageLength2 = strlen( message2 );
@@ -340,7 +371,7 @@ void test_signaling_ParseDescribeSignalingChannelResponse_InvalidTTL_Low( void )
     SignalingResult_t result;
     const char *message =  "{"
         "\"ChannelInfo\": {"
-            "\"SingleMasterConfiguration\": {\"MessageTtlSeconds\": 0}"
+            "\"SingleMasterConfiguration\": {\"MessageTtlSeconds\": 0}"         /* The Valid Range for message TTL is [ 5-120 ] Seconds */
         "}"
     "}";
     size_t messageLength = strlen( message );
@@ -363,7 +394,7 @@ void test_signaling_ParseDescribeSignalingChannelResponse_InvalidTTL_High( void 
     SignalingResult_t result;
     const char *message =  "{"
         "\"ChannelInfo\": {"
-            "\"SingleMasterConfiguration\": {\"MessageTtlSeconds\": 999999999}"
+            "\"SingleMasterConfiguration\": {\"MessageTtlSeconds\": 999999999}"         /* The Valid Range for message TTL is [ 5-120 ] Seconds  */
         "}"
     "}";
     size_t messageLength = strlen( message );
@@ -404,7 +435,7 @@ void test_signaling_ParseDescribeSignalingChannelResponse_InvalidChannel_Type( v
  * @brief Validate Signaling Parse Describe Response functionality for Invalid Channel Name.
  */
 void test_signaling_ParseDescribeSignalingChannelResponse_InvalidChannel_Name( void )
-{   
+{
     SignalingChannelInfo_t channelInfo;
     SignalingResult_t result;
 
@@ -447,15 +478,16 @@ void test_signaling_ParseDescribeSignalingChannelResponse( void )
         "}"
     "}";
     size_t messageLength = strlen( message );
+    const char* pExpectedChannelArn = "arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123";
 
     result = Signaling_ParseDescribeSignalingChannelResponse( message,
                                                               messageLength, &( channelInfo ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL_STRING_LEN( "arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123",
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedChannelArn,
                                   channelInfo.channelArn.pChannelArn,
-                                  channelInfo.channelArn.channelArnLength );
+                                  strlen(pExpectedChannelArn));
     TEST_ASSERT_EQUAL_STRING_LEN( "test-channel",
                                   channelInfo.channelName.pChannelName,
                                   channelInfo.channelName.channelNameLength );
@@ -543,6 +575,10 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest( void )
     char urlBuffer[ 200 ];
     char bodyBuffer[ 100 ];
     SignalingResult_t result;
+    const char * pExpectedUrl = "https://kinesisvideo.us-east-1.amazonaws.com/describeMediaStorageConfiguration";
+    const char * pExpectedBody = "{"
+                                    "\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\""
+                                  "}";
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -550,9 +586,9 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest( void )
     channelArn.pChannelArn = "arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123";
     channelArn.channelArnLength = strlen( channelArn.pChannelArn );
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
@@ -560,8 +596,14 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest( void )
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL_STRING( "https://kinesisvideo.us-east-1.amazonaws.com/describeMediaStorageConfiguration", requestBuffer.pUrl );
-    TEST_ASSERT_EQUAL_STRING( "{\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\"}", requestBuffer.pBody );
+    TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
+                       requestBuffer.urlLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
+                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
+                       requestBuffer.bodyLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
+                              requestBuffer.pBody );
 }
 
 /*-----------------------------------------------------------*/
@@ -577,6 +619,10 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest_SmallLengthRegion
     char urlBuffer[ 200 ];
     char bodyBuffer[ 100 ];
     SignalingResult_t result;
+    const char * pExpectedUrl = "https://kinesisvideo.ca.amazonaws.com/describeMediaStorageConfiguration";
+    const char * pExpectedBody = "{"
+                                    "\"ChannelARN\":\"arn:aws:kinesisvideo:ca:123456789012:channel/test-channel/1234567890123\""
+                                  "}";
 
     awsRegion.pAwsRegion = "ca"; /* The Region Length is < 3 */
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -584,9 +630,9 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest_SmallLengthRegion
     channelArn.pChannelArn = "arn:aws:kinesisvideo:ca:123456789012:channel/test-channel/1234567890123";
     channelArn.channelArnLength = strlen( channelArn.pChannelArn );
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
@@ -594,8 +640,14 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest_SmallLengthRegion
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL_STRING( "https://kinesisvideo.ca.amazonaws.com/describeMediaStorageConfiguration", requestBuffer.pUrl );
-    TEST_ASSERT_EQUAL_STRING( "{\"ChannelARN\":\"arn:aws:kinesisvideo:ca:123456789012:channel/test-channel/1234567890123\"}", requestBuffer.pBody );
+    TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
+                       requestBuffer.urlLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
+                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
+                       requestBuffer.bodyLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
+                              requestBuffer.pBody );
 }
 
 /*-----------------------------------------------------------*/
@@ -611,6 +663,10 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest_ChinaRegion( void
     char urlBuffer[ 200 ];
     char bodyBuffer[ 100 ];
     SignalingResult_t result;
+    const char * pExpectedUrl = "https://kinesisvideo.cn-north-1.amazonaws.com.cn/describeMediaStorageConfiguration";
+    const char * pExpectedBody = "{"
+                                    "\"ChannelARN\":\"arn:aws-cn:kinesisvideo:cn-north-1:123456789012:channel/test-channel/1234567890123\""
+                                  "}";
 
     awsRegion.pAwsRegion = "cn-north-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -618,9 +674,9 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest_ChinaRegion( void
     channelArn.pChannelArn = "arn:aws-cn:kinesisvideo:cn-north-1:123456789012:channel/test-channel/1234567890123";
     channelArn.channelArnLength = strlen( channelArn.pChannelArn );
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
@@ -628,8 +684,14 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest_ChinaRegion( void
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL_STRING( "https://kinesisvideo.cn-north-1.amazonaws.com.cn/describeMediaStorageConfiguration", requestBuffer.pUrl );
-    TEST_ASSERT_EQUAL_STRING( "{\"ChannelARN\":\"arn:aws-cn:kinesisvideo:cn-north-1:123456789012:channel/test-channel/1234567890123\"}", requestBuffer.pBody );
+    TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
+                       requestBuffer.urlLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
+                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
+                       requestBuffer.bodyLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
+                              requestBuffer.pBody );
 }
 
 /*-----------------------------------------------------------*/
@@ -652,9 +714,9 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest_URLOutOfMemory( v
     channelArn.pChannelArn = "arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123";
     channelArn.channelArnLength = strlen( channelArn.pChannelArn );
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
@@ -684,9 +746,9 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest_BodyOutOfMemory( 
     channelArn.pChannelArn = "arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123";
     channelArn.channelArnLength = strlen( channelArn.pChannelArn );
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
@@ -703,8 +765,8 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest_BodyOutOfMemory( 
  */
 void test_signaling_ParseDescribeMediaStorageConfigResponse_BadParams( void )
 {
-    const char * message;
-    size_t messageLength = sizeof( message );
+    const char * message = "Valid-Message";
+    size_t messageLength = strlen(message);
     SignalingMediaStorageConfig_t mediaStorageConfig;
     SignalingResult_t result;
 
@@ -794,23 +856,28 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse( void )
 {
     SignalingMediaStorageConfig_t mediaStorageConfig;
     SignalingResult_t result;
-    const char *message  = "{"
-            "\"MediaStorageConfiguration\": {"
-            "\"Status\": \"ENABLED\","
-            "\"StreamARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:stream/test-stream/1234567890123\""
+    const char *message  =  \
+        "{"
+            "\"MediaStorageConfiguration\":"
+           "{"
+                "\"Status\": \"ENABLED\","
+                "\"StreamARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:stream/test-stream/1234567890123\","
+                "\"Unkown\": \"Unkown Value\""                  /* This will be ignored. */
             "}"
-            "}";
+        "}";
     size_t messageLength = strlen( message );
-
+    const char * pExpectedStreamArn = "arn:aws:kinesisvideo:us-west-2:123456789012:stream/test-stream/1234567890123";
     result = Signaling_ParseDescribeMediaStorageConfigResponse( message,
                                                                 messageLength, &( mediaStorageConfig ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL_STRING_LEN( "ENABLED", mediaStorageConfig.pStatus, mediaStorageConfig.statusLength );
-    TEST_ASSERT_EQUAL_STRING_LEN( "arn:aws:kinesisvideo:us-west-2:123456789012:stream/test-stream/1234567890123",
+    TEST_ASSERT_EQUAL( strlen( pExpectedStreamArn ),
+                       mediaStorageConfig.streamArnLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedStreamArn,
                                   mediaStorageConfig.pStreamArn,
-                                  mediaStorageConfig.streamArnLength );
+                                  strlen(pExpectedStreamArn) );
 }
 
 /*-----------------------------------------------------------*/
@@ -903,6 +970,14 @@ void test_signaling_ConstructCreateSignalingChannelRequest( void )
     char urlBuffer[ 200 ];
     char bodyBuffer[ 500 ];
     SignalingResult_t result;
+    const char * pExpectedUrl = "https://kinesisvideo.us-east-1.amazonaws.com/createSignalingChannel";
+    const char * pExpectedBody = "{"
+                                    "\"ChannelName\":\"Test-Channel\","
+                                    "\"ChannelType\":\"SINGLE_MASTER\","
+                                    "\"SingleMasterConfiguration\":{"
+                                        "\"MessageTtlSeconds\":60"
+                                    "}"
+                                  "}";
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -914,9 +989,9 @@ void test_signaling_ConstructCreateSignalingChannelRequest( void )
     createSignalingChannelRequestInfo.numTags = 0;
     createSignalingChannelRequestInfo.pTags = NULL;
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
@@ -924,8 +999,14 @@ void test_signaling_ConstructCreateSignalingChannelRequest( void )
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL_STRING( "https://kinesisvideo.us-east-1.amazonaws.com/createSignalingChannel", requestBuffer.pUrl );
-    TEST_ASSERT_EQUAL_STRING( "{\"ChannelName\":\"Test-Channel\",\"ChannelType\":\"SINGLE_MASTER\",\"SingleMasterConfiguration\":{\"MessageTtlSeconds\":60}}", requestBuffer.pBody );
+    TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
+                       requestBuffer.urlLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
+                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
+                       requestBuffer.bodyLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
+                              requestBuffer.pBody );                   
 }
 
 /*-----------------------------------------------------------*/
@@ -941,6 +1022,14 @@ void test_signaling_ConstructCreateSignalingChannelRequest_SmallLengthRegion( vo
     char urlBuffer[ 200 ];
     char bodyBuffer[ 500 ];
     SignalingResult_t result;
+    const char * pExpectedUrl = "https://kinesisvideo.ca.amazonaws.com/createSignalingChannel";
+    const char * pExpectedBody = "{"
+                                    "\"ChannelName\":\"Test-Channel\","
+                                    "\"ChannelType\":\"SINGLE_MASTER\","
+                                    "\"SingleMasterConfiguration\":{"
+                                        "\"MessageTtlSeconds\":60"
+                                    "}"
+                                  "}";
 
     awsRegion.pAwsRegion = "ca";            /* The Region Length is < 3 */
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -952,9 +1041,9 @@ void test_signaling_ConstructCreateSignalingChannelRequest_SmallLengthRegion( vo
     createSignalingChannelRequestInfo.numTags = 0;
     createSignalingChannelRequestInfo.pTags = NULL;
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
@@ -962,8 +1051,14 @@ void test_signaling_ConstructCreateSignalingChannelRequest_SmallLengthRegion( vo
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL_STRING( "https://kinesisvideo.ca.amazonaws.com/createSignalingChannel", requestBuffer.pUrl );
-    TEST_ASSERT_EQUAL_STRING( "{\"ChannelName\":\"Test-Channel\",\"ChannelType\":\"SINGLE_MASTER\",\"SingleMasterConfiguration\":{\"MessageTtlSeconds\":60}}", requestBuffer.pBody );
+    TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
+                       requestBuffer.urlLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
+                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
+                       requestBuffer.bodyLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
+                              requestBuffer.pBody );
 }
 
 /*-----------------------------------------------------------*/
@@ -979,6 +1074,14 @@ void test_signaling_ConstructCreateSignalingChannelRequest_ChinaRegion( void )
     char urlBuffer[ 200 ];
     char bodyBuffer[ 500 ];
     SignalingResult_t result;
+    const char * pExpectedUrl = "https://kinesisvideo.cn-north-1.amazonaws.com.cn/createSignalingChannel";
+    const char * pExpectedBody = "{"
+                                    "\"ChannelName\":\"Test-Channel\","
+                                    "\"ChannelType\":\"SINGLE_MASTER\","
+                                    "\"SingleMasterConfiguration\":{"
+                                        "\"MessageTtlSeconds\":60"
+                                    "}"
+                                  "}";
 
     awsRegion.pAwsRegion = "cn-north-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -990,9 +1093,9 @@ void test_signaling_ConstructCreateSignalingChannelRequest_ChinaRegion( void )
     createSignalingChannelRequestInfo.numTags = 0;
     createSignalingChannelRequestInfo.pTags = NULL;
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
@@ -1000,8 +1103,14 @@ void test_signaling_ConstructCreateSignalingChannelRequest_ChinaRegion( void )
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL_STRING( "https://kinesisvideo.cn-north-1.amazonaws.com.cn/createSignalingChannel", requestBuffer.pUrl );
-    TEST_ASSERT_EQUAL_STRING( "{\"ChannelName\":\"Test-Channel\",\"ChannelType\":\"SINGLE_MASTER\",\"SingleMasterConfiguration\":{\"MessageTtlSeconds\":60}}", requestBuffer.pBody );
+    TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
+                       requestBuffer.urlLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
+                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
+                       requestBuffer.bodyLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
+                              requestBuffer.pBody );
 }
 
 /*-----------------------------------------------------------*/
@@ -1018,6 +1127,20 @@ void test_signaling_ConstructCreateSignalingChannelRequest_WithTags( void )
     char urlBuffer[ 200 ];
     char bodyBuffer[ 500 ];
     SignalingResult_t result;
+    const char * pExpectedUrl = "https://kinesisvideo.us-east-1.amazonaws.com/createSignalingChannel";
+    const char * pExpectedBody = "{"
+                                    "\"ChannelName\":\"Test-Channel\","
+                                    "\"ChannelType\":\"SINGLE_MASTER\","
+                                    "\"SingleMasterConfiguration\":{"
+                                        "\"MessageTtlSeconds\":60"
+                                    "},"
+                                    "\"Tags\":["
+                                        "{"
+                                            "\"Key\":\"Tag1\","
+                                            "\"Value\":\"Value1\""
+                                        "}"
+                                    "]"
+                                  "}";
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -1034,9 +1157,9 @@ void test_signaling_ConstructCreateSignalingChannelRequest_WithTags( void )
     createSignalingChannelRequestInfo.numTags = 1;
     createSignalingChannelRequestInfo.pTags = tags;
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
@@ -1044,8 +1167,14 @@ void test_signaling_ConstructCreateSignalingChannelRequest_WithTags( void )
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL_STRING( "https://kinesisvideo.us-east-1.amazonaws.com/createSignalingChannel", requestBuffer.pUrl );
-    TEST_ASSERT_EQUAL_STRING( "{\"ChannelName\":\"Test-Channel\",\"ChannelType\":\"SINGLE_MASTER\",\"SingleMasterConfiguration\":{\"MessageTtlSeconds\":60}"",\"Tags\":[{\"Key\":\"Tag1\",\"Value\":\"Value1\"}]}", requestBuffer.pBody );
+    TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
+                       requestBuffer.urlLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
+                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
+                       requestBuffer.bodyLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
+                              requestBuffer.pBody );
 }
 
 /*-----------------------------------------------------------*/
@@ -1055,8 +1184,8 @@ void test_signaling_ConstructCreateSignalingChannelRequest_WithTags( void )
  */
 void test_signaling_ParseCreateSignalingChannelResponse_BadParams( void )
 {
-    const char * message;
-    size_t messageLength = sizeof( message );
+    const char * message = "Valid-Message";
+    size_t messageLength = strlen( message );
     SignalingChannelArn_t channelArn = { 0 };
     SignalingResult_t result;
 
@@ -1118,22 +1247,24 @@ void test_signaling_ParseCreateSignalingChannelResponse_UnexpectedResponse( void
  */
 void test_signaling_ParseCreateSignalingChannelResponse( void )
 {
+    SignalingChannelArn_t channelArn = { 0 };
+    SignalingResult_t result;
     const char *message = "{"
         "\"ChannelARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123\""
     "}";
     size_t messageLength = strlen( message );
-    SignalingChannelArn_t channelArn = { 0 };
-    SignalingResult_t result;
+    const char * pExpectedChannelArn = "arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123";
 
     result = Signaling_ParseCreateSignalingChannelResponse( message,
                                                             messageLength, &( channelArn ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL_STRING_LEN( "arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123",
+    TEST_ASSERT_EQUAL( strlen(pExpectedChannelArn), channelArn.channelArnLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedChannelArn,
                                   channelArn.pChannelArn,
                                   channelArn.channelArnLength );
-    TEST_ASSERT_EQUAL( 78, channelArn.channelArnLength );
+    
 }
 
 /*-----------------------------------------------------------*/
@@ -1224,6 +1355,14 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest( void )
     char urlBuffer[ 200 ];
     char bodyBuffer[ 500 ];
     SignalingResult_t result;
+    const char * pExpectedUrl = "https://kinesisvideo.us-east-1.amazonaws.com/getSignalingChannelEndpoint";
+    const char * pExpectedBody = "{"
+                                    "\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\","
+                                    "\"SingleMasterChannelEndpointConfiguration\":{"
+                                        "\"Protocols\":[\"HTTPS\"],"
+                                        "\"Role\":\"MASTER\""
+                                    "}"
+                                  "}";
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -1233,9 +1372,9 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest( void )
     getSignalingChannelEndPointRequestInfo.role = SIGNALING_ROLE_MASTER;
     getSignalingChannelEndPointRequestInfo.protocols = SIGNALING_PROTOCOL_HTTPS;
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
@@ -1243,10 +1382,14 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest( void )
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL_STRING( "https://kinesisvideo.us-east-1.amazonaws.com/getSignalingChannelEndpoint", requestBuffer.pUrl );
-    TEST_ASSERT_TRUE( strstr( requestBuffer.pBody, "\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\"" ) != NULL );
-    TEST_ASSERT_TRUE( strstr( requestBuffer.pBody, "\"Protocols\":[\"HTTPS\"]" ) != NULL );
-    TEST_ASSERT_TRUE( strstr( requestBuffer.pBody, "\"Role\":\"MASTER\"" ) != NULL );
+    TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
+                       requestBuffer.urlLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
+                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
+                       requestBuffer.bodyLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
+                              requestBuffer.pBody );
 }
 
 /*-----------------------------------------------------------*/

--- a/test/unit-test/signaling_api/signaling_api_utest.c
+++ b/test/unit-test/signaling_api/signaling_api_utest.c
@@ -139,15 +139,15 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_SmallLengthRegion( 
     SignalingAwsRegion_t awsRegion = { 0 };
     SignalingChannelName_t channelName = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
     char urlBuffer[ 200 ];
     char bodyBuffer[ 100 ];
-    SignalingResult_t result;
     const char * pExpectedUrl = "https://kinesisvideo.ca.amazonaws.com/describeSignalingChannel";
     const char * pExpectedBody = "{"
                                     "\"ChannelName\":\"Test-Channel-China\""
                                   "}";
 
-    awsRegion.pAwsRegion = "ca"; /* The Region Length is < 3 */
+    awsRegion.pAwsRegion = "ca"; /* The Region Length is < 3. */
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
 
     channelName.pChannelName = "Test-Channel-China";
@@ -159,7 +159,8 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_SmallLengthRegion( 
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDescribeSignalingChannelRequest( &( awsRegion ),
-                                                                 &( channelName ), &( requestBuffer ) );
+                                                                 &( channelName ),
+                                                                 &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
@@ -183,9 +184,9 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_ChinaRegion( void )
     SignalingAwsRegion_t awsRegion = { 0 };
     SignalingChannelName_t channelName = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
     char urlBuffer[ 200 ];
     char bodyBuffer[ 100 ];
-    SignalingResult_t result;
     const char * pExpectedUrl = "https://kinesisvideo.cn-east-1.amazonaws.com.cn/describeSignalingChannel";
     const char * pExpectedBody = "{"
                                     "\"ChannelName\":\"Test-Channel-China\""
@@ -203,7 +204,8 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_ChinaRegion( void )
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDescribeSignalingChannelRequest( &( awsRegion ),
-                                                                 &( channelName ), &( requestBuffer ) );
+                                                                 &( channelName ),
+                                                                 &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
@@ -222,14 +224,14 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_ChinaRegion( void )
 /**
  * @brief Validate Signaling Construct Describe Channel Request functionality.
  */
-void test_signaling_ConstructDescribeSignalingChannelRequest_URLOutofMemory( void )
+void test_signaling_ConstructDescribeSignalingChannelRequest_UrlOutofMemory( void )
 {
     SignalingAwsRegion_t awsRegion = { 0 };
     SignalingChannelName_t channelName = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
-    char urlBuffer[ 69 ];         /* The url buffer is small */
-    char bodyBuffer[ 100 ];
     SignalingResult_t result;
+    char urlBuffer[ 69 ]; /* The url buffer is too small to fit the complete URL. */
+    char bodyBuffer[ 100 ];
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -243,7 +245,8 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_URLOutofMemory( voi
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDescribeSignalingChannelRequest( &( awsRegion ),
-                                                                 &( channelName ), &( requestBuffer ) );
+                                                                 &( channelName ),
+                                                                 &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
                        result );
@@ -259,9 +262,9 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_BodyOutofMemory( vo
     SignalingAwsRegion_t awsRegion = { 0 };
     SignalingChannelName_t channelName = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
-    char urlBuffer[ 200 ];
-    char bodyBuffer[ 30 ];         /* The body buffer is small */
     SignalingResult_t result;
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 30 ]; /* The body buffer is too small to fit the complete body. */
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -275,7 +278,8 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_BodyOutofMemory( vo
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDescribeSignalingChannelRequest( &( awsRegion ),
-                                                                 &( channelName ), &( requestBuffer ) );
+                                                                 &( channelName ),
+                                                                 &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
                        result );
@@ -288,19 +292,21 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_BodyOutofMemory( vo
  */
 void test_signaling_ParseDescribeSignalingChannelResponse_BadParams( void )
 {
-    const char * message = "Input Message";
-    size_t messageLength = strlen( message );
     SignalingChannelInfo_t channelInfo;
     SignalingResult_t result;
+    const char * message = "Input Message";
+    size_t messageLength = strlen( message );
 
     result = Signaling_ParseDescribeSignalingChannelResponse( NULL,
-                                                              messageLength, &( channelInfo ) );
+                                                              messageLength,
+                                                              &( channelInfo ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     result = Signaling_ParseDescribeSignalingChannelResponse( message,
-                                                              messageLength, NULL );
+                                                              messageLength,
+                                                              NULL );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -313,55 +319,65 @@ void test_signaling_ParseDescribeSignalingChannelResponse_BadParams( void )
  */
 void test_signaling_ParseDescribeSignalingChannelResponse_InvalidJson( void )
 {
-    const char * message = "{\"ChannelInfo\": {";        /* Missing Closing Braces */
-    size_t messageLength = strlen( message );
     SignalingChannelInfo_t channelInfo;
     SignalingResult_t result;
+    const char * message = "{\"ChannelInfo\": {"; /* Missing Closing Brace. */
+    size_t messageLength = strlen( message );
 
     result = Signaling_ParseDescribeSignalingChannelResponse( message,
-                                                              messageLength, &( channelInfo ) );
+                                                              messageLength,
+                                                              &( channelInfo ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
                        result );
 
     /* <--------------------------------------------------------------------> */
 
-    const char *message2 = "{"
-        "\"ChannelInfo\": {"
-            "\"SingleMasterConfiguration\": {\"MessbkpTtlSeconds\": 60}"        /* The SingleMasterConfiguration Contains Invalid Value */
+    const char *message2 =
+    "{"
+        "\"ChannelInfo\":"
+        "{"
+            "\"SingleMasterConfiguration\":"
+            "{"
+                "\"MessbkpTtlSeconds\": 60" /* Invalid key. */
+            "}"
         "}"
     "}";
     size_t messageLength2 = strlen( message2 );
 
     result = Signaling_ParseDescribeSignalingChannelResponse( message2,
-                                                              messageLength2, &( channelInfo ) );
+                                                              messageLength2,
+                                                              &( channelInfo ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
                        result );
 
     /* <--------------------------------------------------------------------> */
 
-    const char *message3 = "{"
-    "}";                                                                   /* Empty Message */
+    const char *message3 = "{}"; /* Empty Message. */
     size_t messageLength3 = strlen( message3 );
 
     result = Signaling_ParseDescribeSignalingChannelResponse( message3,
-                                                              messageLength3, &( channelInfo ) );
+                                                              messageLength3,
+                                                              &( channelInfo ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
                        result );
 
     /* <--------------------------------------------------------------------> */
 
-    const char *message4 = "{"
-        "\"ChannelInfo\": {"
-            "\"SingleMasterConfiguration\": {}"                             /* Empty Single Master Configuration */
+    const char *message4 =
+    "{"
+        "\"ChannelInfo\":"
+        "{"
+            "\"SingleMasterConfiguration\": {}" /* Empty Single Master Configuration. */
         "}"
-    "}";                                                              
+    "}";
     size_t messageLength4 = strlen( message4 );
 
     result = Signaling_ParseDescribeSignalingChannelResponse( message4,
-                                                              messageLength4, &( channelInfo ) );
+                                                              messageLength4,
+                                                              &( channelInfo ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
                        result );
@@ -375,43 +391,55 @@ void test_signaling_ParseDescribeSignalingChannelResponse_InvalidJson( void )
  */
 void test_signaling_ParseDescribeSignalingChannelResponse_UnexpectedResponse( void )
 {
-    const char * message = "{"
-        "\"ChannelInfo\": ["                                                                    /* Opening Bracket Not JSON Object Type */
-            "{\"ChannelARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123\"}"
-        "]"                                                                                     /* Closing Bracket Not JSON Object Type */  
-    "}";
-    size_t messageLength = strlen( message );
     SignalingChannelInfo_t channelInfo;
     SignalingResult_t result;
+    const char * message =
+    "{"
+        "\"ChannelInfo\":"
+        "[" /* Unexpected JSON array. */
+            "{"
+                "\"ChannelARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123\""
+            "}"
+        "]"
+    "}";
+    size_t messageLength = strlen( message );
 
     result = Signaling_ParseDescribeSignalingChannelResponse( message,
-                                                              messageLength, &( channelInfo ) );
+                                                              messageLength,
+                                                              &( channelInfo ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
 
     /*<----------------------------------------------------------------->*/
 
-    const char * message2 = "{"
-        "\"Unkown\": {"                           
+    const char * message2 =
+    "{"
+        "\"Unkown\":" /* Unexpected key. */
+        "{"
             "\"ChannelARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123\""
-        "}"                                        
+        "}"
     "}";
     size_t messageLength2 = strlen( message2 );
 
     result = Signaling_ParseDescribeSignalingChannelResponse( message2,
-                                                              messageLength2, &( channelInfo ) );
+                                                              messageLength2,
+                                                              &( channelInfo ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
 
     /*<----------------------------------------------------------------->*/
 
-    const char * message3 = "{\"ChannelXXXX\": {}}";            /* The Key is not known though the length is same as "ChannelInfo". */
+    const char * message3 =
+    "{"
+        "\"ChannelXXXX\": {}" /* Unexpected key though the length is same as "ChannelInfo". */
+    "}";
     size_t messageLength3 = strlen( message3 );
 
     result = Signaling_ParseDescribeSignalingChannelResponse( message3,
-                                                              messageLength3, &( channelInfo ) );
+                                                              messageLength3,
+                                                              &( channelInfo ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
@@ -422,19 +450,25 @@ void test_signaling_ParseDescribeSignalingChannelResponse_UnexpectedResponse( vo
 /**
  * @brief Validate Signaling Parse Describe Response functionality for Invalid TTL.
  */
-void test_signaling_ParseDescribeSignalingChannelResponse_InvalidTTL_Low( void )
+void test_signaling_ParseDescribeSignalingChannelResponse_TttLow( void )
 {
     SignalingChannelInfo_t channelInfo;
     SignalingResult_t result;
-    const char *message =  "{"
-        "\"ChannelInfo\": {"
-            "\"SingleMasterConfiguration\": {\"MessageTtlSeconds\": 0}"         /* The Valid Range for message TTL is [ 5-120 ] Seconds */
+    const char *message =
+    "{"
+        "\"ChannelInfo\":"
+        "{"
+            "\"SingleMasterConfiguration\":"
+            "{"
+                "\"MessageTtlSeconds\": 0" /* The valid range for message TTL is [ 5-120 ] seconds. */
+            "}"
         "}"
     "}";
     size_t messageLength = strlen( message );
 
     result = Signaling_ParseDescribeSignalingChannelResponse( message,
-                                                              messageLength, &( channelInfo ) );
+                                                              messageLength,
+                                                              &( channelInfo ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_TTL,
                        result );
@@ -445,19 +479,25 @@ void test_signaling_ParseDescribeSignalingChannelResponse_InvalidTTL_Low( void )
 /**
  * @brief Validate Signaling Parse Describe Response functionality for Invalid TTL.
  */
-void test_signaling_ParseDescribeSignalingChannelResponse_InvalidTTL_High( void )
+void test_signaling_ParseDescribeSignalingChannelResponse_TtlHigh( void )
 {
     SignalingChannelInfo_t channelInfo;
     SignalingResult_t result;
-    const char *message =  "{"
-        "\"ChannelInfo\": {"
-            "\"SingleMasterConfiguration\": {\"MessageTtlSeconds\": 999}"         /* The Valid Range for message TTL is [ 5-120 ] Seconds  */
+    const char *message =
+    "{"
+        "\"ChannelInfo\":"
+        "{"
+            "\"SingleMasterConfiguration\":"
+            "{"
+                "\"MessageTtlSeconds\": 999" /* The valid range for message TTL is [ 5-120 ] seconds. */
+            "}"
         "}"
     "}";
     size_t messageLength = strlen( message );
 
     result = Signaling_ParseDescribeSignalingChannelResponse( message,
-                                                              messageLength, &( channelInfo ) );
+                                                              messageLength,
+                                                              &( channelInfo ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_TTL,
                        result );
@@ -468,19 +508,25 @@ void test_signaling_ParseDescribeSignalingChannelResponse_InvalidTTL_High( void 
 /**
  * @brief Validate Signaling Parse Describe Response functionality for Invalid TTL.
  */
-void test_signaling_ParseDescribeSignalingChannelResponse_InvalidTTL_Buffer( void )
+void test_signaling_ParseDescribeSignalingChannelResponse_InvalidTtl( void )
 {
     SignalingChannelInfo_t channelInfo;
     SignalingResult_t result;
-    const char *message =  "{"
-        "\"ChannelInfo\": {"
-            "\"SingleMasterConfiguration\": {\"MessageTtlSeconds\": 9999999}"         /* The Valid Range for message TTL is < SIGNALING_CHANNEL_TTL_SECONDS_BUFFER_MAX ( 5 ), Here is 7  */
+    const char *message =
+    "{"
+        "\"ChannelInfo\":"
+        "{"
+            "\"SingleMasterConfiguration\":"
+            "{"
+                "\"MessageTtlSeconds\": 9999999" /* TTL value length larger than SIGNALING_CHANNEL_TTL_SECONDS_BUFFER_MAX ( 5 ). */
+            "}"
         "}"
     "}";
     size_t messageLength = strlen( message );
 
     result = Signaling_ParseDescribeSignalingChannelResponse( message,
-                                                              messageLength, &( channelInfo ) );
+                                                              messageLength,
+                                                              &( channelInfo ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_TTL,
                        result );
@@ -495,15 +541,18 @@ void test_signaling_ParseDescribeSignalingChannelResponse_InvalidChannel_Type( v
 {
     SignalingChannelInfo_t channelInfo;
     SignalingResult_t result;
-    const char *message = "{"
-        "\"ChannelInfo\": {"
+    const char *message =
+    "{"
+        "\"ChannelInfo\":"
+        "{"
             "\"ChannelType\": \"INVALID_TYPE\""
         "}"
     "}";
     size_t messageLength = strlen( message );
 
     result = Signaling_ParseDescribeSignalingChannelResponse( message,
-                                                              messageLength, &( channelInfo ) );
+                                                              messageLength,
+                                                              &( channelInfo ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_CHANNEL_TYPE,
                        result );
@@ -512,27 +561,32 @@ void test_signaling_ParseDescribeSignalingChannelResponse_InvalidChannel_Type( v
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate Signaling Parse Describe Response functionality for Invalid Channel Name.
+ * @brief Validate Signaling Parse Describe Response functionality for too long Channel Name.
  */
-void test_signaling_ParseDescribeSignalingChannelResponse_InvalidChannel_Name( void )
+void test_signaling_ParseDescribeSignalingChannelResponse_ChannelNameTooLong( void )
 {
     SignalingChannelInfo_t channelInfo;
     SignalingResult_t result;
-
     char longChannelName[ SIGNALING_CHANNEL_NAME_MAX_LEN + 10 ];
+    char message[ 1000 ];
 
     memset( longChannelName, 'a', sizeof( longChannelName ) - 1 );
     longChannelName[ sizeof( longChannelName ) - 1 ] = '\0';
-    char message[ 1000 ];
-    snprintf(message, sizeof(message), "{"
-        "\"ChannelInfo\": {"
-            "\"ChannelName\": \"%s\""
-        "}"
-    "}", longChannelName);
+
+    snprintf( message,
+              sizeof( message ),
+              "{"
+                    "\"ChannelInfo\":"
+                    "{"
+                        "\"ChannelName\": \"%s\""
+                    "}"
+               "}",
+               longChannelName );
     size_t messageLength = strlen( message );
 
     result = Signaling_ParseDescribeSignalingChannelResponse( message,
-                                                              messageLength, &( channelInfo ) );
+                                                              messageLength,
+                                                              &( channelInfo ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_CHANNEL_NAME,
                        result );
@@ -547,8 +601,10 @@ void test_signaling_ParseDescribeSignalingChannelResponse( void )
 {
     SignalingChannelInfo_t channelInfo;
     SignalingResult_t result;
-    const char *message = "{"
-        "\"ChannelInfo\": {"
+    const char *message =
+    "{"
+        "\"ChannelInfo\":"
+        "{"
             "\"ChannelARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123\","
             "\"ChannelName\": \"test-channel\","
             "\"ChannelStatus\": \"ACTIVE\","
@@ -556,27 +612,42 @@ void test_signaling_ParseDescribeSignalingChannelResponse( void )
             "\"CreationTime\": \"2023-05-01T12:00:00Z\","
             "\"SingleMasterConfiguration\": {\"MessageTtlSeconds\": 60},"
             "\"Version\": \"1\","
-            "\"Unkown\": \"200\""                       /* Unkown Tag --> Will be skipped */
+            "\"Unkown\": \"200\"" /* Unkown Tag --> Will be skipped. */
         "}"
     "}";
     size_t messageLength = strlen( message );
     const char * pExpectedChannelArn = "arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123";
 
     result = Signaling_ParseDescribeSignalingChannelResponse( message,
-                                                              messageLength, &( channelInfo ) );
+                                                              messageLength,
+                                                              &( channelInfo ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
+    TEST_ASSERT_EQUAL( strlen( pExpectedChannelArn ),
+                       channelInfo.channelArn.channelArnLength );
     TEST_ASSERT_EQUAL_STRING_LEN( pExpectedChannelArn,
                                   channelInfo.channelArn.pChannelArn,
-                                  strlen( pExpectedChannelArn ) );
+                                  channelInfo.channelArn.channelArnLength );
+    TEST_ASSERT_EQUAL( strlen( "test-channel" ),
+                       channelInfo.channelName.channelNameLength );
     TEST_ASSERT_EQUAL_STRING_LEN( "test-channel",
                                   channelInfo.channelName.pChannelName,
                                   channelInfo.channelName.channelNameLength );
-    TEST_ASSERT_EQUAL_STRING_LEN( "ACTIVE", channelInfo.pChannelStatus, channelInfo.channelStatusLength );
-    TEST_ASSERT_EQUAL( SIGNALING_TYPE_CHANNEL_SINGLE_MASTER, channelInfo.channelType );
-    TEST_ASSERT_EQUAL( 60, channelInfo.messageTtlSeconds );
-    TEST_ASSERT_EQUAL_STRING_LEN( "1", channelInfo.pVersion, channelInfo.versionLength );
+    TEST_ASSERT_EQUAL( strlen( "ACTIVE" ),
+                       channelInfo.channelStatusLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "ACTIVE",
+                                  channelInfo.pChannelStatus,
+                                  channelInfo.channelStatusLength );
+    TEST_ASSERT_EQUAL( SIGNALING_TYPE_CHANNEL_SINGLE_MASTER,
+                       channelInfo.channelType );
+    TEST_ASSERT_EQUAL( 60,
+                       channelInfo.messageTtlSeconds );
+    TEST_ASSERT_EQUAL( strlen( "1" ),
+                       channelInfo.versionLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "1",
+                                  channelInfo.pVersion,
+                                  channelInfo.versionLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -592,35 +663,43 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest_BadParams( void )
     SignalingResult_t result;
 
     result = Signaling_ConstructDescribeMediaStorageConfigRequest( NULL,
-                                                                   &( channelArn ), &( requestBuffer ) );
+                                                                   &( channelArn ),
+                                                                   &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     awsRegion.pAwsRegion = NULL;
+
     result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
-                                                                   &( channelArn ), &( requestBuffer ) );
+                                                                   &( channelArn ),
+                                                                   &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
     result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
-                                                                   NULL, &( requestBuffer ) );
+                                                                   NULL,
+                                                                   &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
-                                                                   &( channelArn ), NULL );
+                                                                   &( channelArn ),
+                                                                   NULL );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     requestBuffer.pUrl = NULL;
+
     result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
-                                                                   &( channelArn ), &( requestBuffer ) );
+                                                                   &( channelArn ),
+                                                                   &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -628,8 +707,10 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest_BadParams( void )
     requestBuffer.pUrl = "https://kinesisvideo.cn-east-1.amazonaws.com.cn/describeSignalingChannel";
     requestBuffer.urlLength = strlen( requestBuffer.pUrl );
     requestBuffer.pBody = NULL;
+
     result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
-                                                                   &( channelArn ), &( requestBuffer ) );
+                                                                   &( channelArn ),
+                                                                   &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -637,8 +718,10 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest_BadParams( void )
     requestBuffer.pBody = "{\"ChannelName\":\"Test-Channel-China\"}";
     requestBuffer.bodyLength = strlen( requestBuffer.pBody );
     channelArn.pChannelArn = NULL;
+
     result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
-                                                                   &( channelArn ), &( requestBuffer ) );
+                                                                   &( channelArn ),
+                                                                   &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -654,13 +737,14 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest( void )
     SignalingAwsRegion_t awsRegion = { 0 };
     SignalingChannelArn_t channelArn = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
     char urlBuffer[ 200 ];
     char bodyBuffer[ 100 ];
-    SignalingResult_t result;
     const char * pExpectedUrl = "https://kinesisvideo.us-east-1.amazonaws.com/describeMediaStorageConfiguration";
-    const char * pExpectedBody = "{"
-                                    "\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\""
-                                  "}";
+    const char * pExpectedBody =
+    "{"
+        "\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\""
+    "}";
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -674,18 +758,21 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest( void )
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
-                                                                   &( channelArn ), &( requestBuffer ) );
+                                                                   &( channelArn ),
+                                                                   &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
                        requestBuffer.urlLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
-                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
+                                  requestBuffer.pUrl,
+                                  requestBuffer.urlLength  );
     TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
                        requestBuffer.bodyLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
-                              requestBuffer.pBody );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedBody,
+                                  requestBuffer.pBody,
+                                  requestBuffer.bodyLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -698,15 +785,16 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest_SmallLengthRegion
     SignalingAwsRegion_t awsRegion = { 0 };
     SignalingChannelArn_t channelArn = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
     char urlBuffer[ 200 ];
     char bodyBuffer[ 100 ];
-    SignalingResult_t result;
     const char * pExpectedUrl = "https://kinesisvideo.ca.amazonaws.com/describeMediaStorageConfiguration";
-    const char * pExpectedBody = "{"
-                                    "\"ChannelARN\":\"arn:aws:kinesisvideo:ca:123456789012:channel/test-channel/1234567890123\""
-                                  "}";
+    const char * pExpectedBody =
+    "{"
+        "\"ChannelARN\":\"arn:aws:kinesisvideo:ca:123456789012:channel/test-channel/1234567890123\""
+    "}";
 
-    awsRegion.pAwsRegion = "ca"; /* The Region Length is < 3 */
+    awsRegion.pAwsRegion = "ca"; /* The Region Length is < 3. */
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
 
     channelArn.pChannelArn = "arn:aws:kinesisvideo:ca:123456789012:channel/test-channel/1234567890123";
@@ -718,18 +806,21 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest_SmallLengthRegion
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
-                                                                   &( channelArn ), &( requestBuffer ) );
+                                                                   &( channelArn ),
+                                                                   &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
                        requestBuffer.urlLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
-                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
+                                  requestBuffer.pUrl,
+                                  requestBuffer.urlLength );
     TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
                        requestBuffer.bodyLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
-                              requestBuffer.pBody );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedBody,
+                                  requestBuffer.pBody,
+                                  requestBuffer.bodyLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -742,13 +833,14 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest_ChinaRegion( void
     SignalingAwsRegion_t awsRegion = { 0 };
     SignalingChannelArn_t channelArn = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
     char urlBuffer[ 200 ];
     char bodyBuffer[ 100 ];
-    SignalingResult_t result;
     const char * pExpectedUrl = "https://kinesisvideo.cn-north-1.amazonaws.com.cn/describeMediaStorageConfiguration";
-    const char * pExpectedBody = "{"
-                                    "\"ChannelARN\":\"arn:aws-cn:kinesisvideo:cn-north-1:123456789012:channel/test-channel/1234567890123\""
-                                  "}";
+    const char * pExpectedBody =
+    "{"
+        "\"ChannelARN\":\"arn:aws-cn:kinesisvideo:cn-north-1:123456789012:channel/test-channel/1234567890123\""
+    "}";
 
     awsRegion.pAwsRegion = "cn-north-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -762,18 +854,21 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest_ChinaRegion( void
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
-                                                                   &( channelArn ), &( requestBuffer ) );
+                                                                   &( channelArn ),
+                                                                   &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
                        requestBuffer.urlLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
-                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
+                                  requestBuffer.pUrl,
+                                  requestBuffer.urlLength );
     TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
                        requestBuffer.bodyLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
-                              requestBuffer.pBody );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedBody,
+                                  requestBuffer.pBody,
+                                  requestBuffer.bodyLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -781,14 +876,14 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest_ChinaRegion( void
 /**
  * @brief Validate Signaling Construct Describe Media Storage Config Request functionality.
  */
-void test_signaling_ConstructDescribeMediaStorageConfigRequest_URLOutOfMemory( void )
+void test_signaling_ConstructDescribeMediaStorageConfigRequest_UrlOutOfMemory( void )
 {
     SignalingAwsRegion_t awsRegion = { 0 };
     SignalingChannelArn_t channelArn = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
-    char urlBuffer[ 78 ];     /* The url buffer is small */
-    char bodyBuffer[ 100 ];
     SignalingResult_t result;
+    char urlBuffer[ 78 ]; /* The url buffer is too small to fit the complete URL. */
+    char bodyBuffer[ 100 ];
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -802,7 +897,8 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest_URLOutOfMemory( v
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
-                                                                   &( channelArn ), &( requestBuffer ) );
+                                                                   &( channelArn ),
+                                                                   &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
                        result );
@@ -818,9 +914,9 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest_BodyOutOfMemory( 
     SignalingAwsRegion_t awsRegion = { 0 };
     SignalingChannelArn_t channelArn = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
-    char urlBuffer[ 200 ];
-    char bodyBuffer[ 95 ];       /* The body buffer is small */
     SignalingResult_t result;
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 95 ]; /* The body buffer is too small to fit the complete body. */
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -834,7 +930,8 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest_BodyOutOfMemory( 
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
-                                                                   &( channelArn ), &( requestBuffer ) );
+                                                                   &( channelArn ),
+                                                                   &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
                        result );
@@ -847,19 +944,21 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest_BodyOutOfMemory( 
  */
 void test_signaling_ParseDescribeMediaStorageConfigResponse_BadParams( void )
 {
-    const char * message = "Valid-Message";
-    size_t messageLength = strlen( message );
     SignalingMediaStorageConfig_t mediaStorageConfig;
     SignalingResult_t result;
+    const char * message = "Valid-Message";
+    size_t messageLength = strlen( message );
 
     result = Signaling_ParseDescribeMediaStorageConfigResponse( NULL,
-                                                                messageLength, &( mediaStorageConfig ) );
+                                                                messageLength,
+                                                                &( mediaStorageConfig ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     result = Signaling_ParseDescribeMediaStorageConfigResponse( message,
-                                                                messageLength, NULL );
+                                                                messageLength,
+                                                                NULL );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -872,24 +971,26 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse_BadParams( void )
  */
 void test_signaling_ParseDescribeMediaStorageConfigResponse_InvalidJson( void )
 {
-    const char * message = "{\"MediaStorageConfiguration\": {";  /* Missing closing brace */
-    size_t messageLength = sizeof( message );
     SignalingMediaStorageConfig_t mediaStorageConfig;
     SignalingResult_t result;
+    const char * message = "{\"MediaStorageConfiguration\": {";  /* Missing closing brace. */
+    size_t messageLength = sizeof( message );
 
     result = Signaling_ParseDescribeMediaStorageConfigResponse( message,
-                                                                messageLength, &( mediaStorageConfig ) );
+                                                                messageLength,
+                                                                &( mediaStorageConfig ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
                        result );
 
     /* <--------------------------------------------------------------------> */
-    const char * message2 = "{"                                  /* Empty JSON */
-                            "}";
+
+    const char * message2 = "{}"; /* Empty JSON. */
     size_t messageLength2 = strlen( message2 );
 
     result = Signaling_ParseDescribeMediaStorageConfigResponse( message2,
-                                                                messageLength2, &( mediaStorageConfig ) );
+                                                                messageLength2,
+                                                                &( mediaStorageConfig ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
                        result );
@@ -904,13 +1005,15 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse_UnexpectedResponse( 
 {
     SignalingMediaStorageConfig_t mediaStorageConfig;
     SignalingResult_t result;
-    const char * message =  \
-        "{"
-            "\"PediaStorageConfiguration\":"               
-           "["                                                                              /* Opening Bracket Not JSON Object Type */
-                "{\"StreamARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:stream/test-stream/1234567890123\"}"
-            "]"                                                                             /* Closing Bracket Not JSON Object Type */
-        "}";
+    const char * message =
+    "{"
+        "\"MediaStorageConfiguration\":"
+        "[" /* Unexpected JSON array. */
+            "{"
+                "\"StreamARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:stream/test-stream/1234567890123\""
+            "}"
+        "]"
+    "}";
     size_t messageLength = strlen( message );
 
 
@@ -919,38 +1022,42 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse_UnexpectedResponse( 
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
+
     /*<----------------------------------------------------------------->*/
 
-    const char * message2 =  \
+    const char * message2 =
+    "{"
+        "\"Unkown\":" /* Unkown Key. */
         "{"
-            "\"Unkown\":"                    /* Unkown Key */      
-           "{"             
-                "\"Status\": \"ENABLED\","
-                "\"StreamARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:stream/test-stream/1234567890123\""
-            "}"          
-        "}";
+            "\"Status\": \"ENABLED\","
+            "\"StreamARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:stream/test-stream/1234567890123\""
+        "}"
+    "}";
     size_t messageLength2 = strlen( message2 );
 
 
     result = Signaling_ParseDescribeMediaStorageConfigResponse( message2,
-                                                                messageLength2, &( mediaStorageConfig ) );
+                                                                messageLength2,
+                                                                &( mediaStorageConfig ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
+
     /*<----------------------------------------------------------------->*/
 
-    const char * message3 =  \
+    const char * message3 =
+    "{"
+        "\"PediaStorageConfiguration\":" /* Unknown key even though length of the key is same as "MediaStorageConfiguration". */
         "{"
-            "\"PediaStorageConfiguration\":"                /* Key is not known, even though length of the key is same as "MediaStorageConfiguration". */
-           "{"
-                "\"Status\": \"ENABLED\","
-                "\"StreamARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:stream/test-stream/1234567890123\""
-            "}"
-        "}";
+            "\"Status\": \"ENABLED\","
+            "\"StreamARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:stream/test-stream/1234567890123\""
+        "}"
+    "}";
     size_t messageLength3 = strlen( message3 );
 
     result = Signaling_ParseDescribeMediaStorageConfigResponse( message3,
-                                                                messageLength3, &( mediaStorageConfig ) );
+                                                                messageLength3,
+                                                                &( mediaStorageConfig ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
@@ -965,21 +1072,30 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse_MissingFields( void 
 {
     SignalingMediaStorageConfig_t mediaStorageConfig;
     SignalingResult_t result;
-    const char *message = "{"
-        "\"MediaStorageConfiguration\": {"
+    const char *message =
+    "{"
+        "\"MediaStorageConfiguration\":"
+        "{"
             "\"Status\": \"ENABLED\""
-            // Missing StreamARN
+            /* Missing StreamARN. */
         "}"
     "}";
     size_t messageLength = strlen( message );
 
     result = Signaling_ParseDescribeMediaStorageConfigResponse( message,
-                                                                messageLength, &( mediaStorageConfig ) );
+                                                                messageLength,
+                                                                &( mediaStorageConfig ) );
 
-    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK, result );
-    TEST_ASSERT_EQUAL_STRING_LEN( "ENABLED", mediaStorageConfig.pStatus, mediaStorageConfig.statusLength );
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( strlen( "ENABLED" ),
+                       mediaStorageConfig.statusLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "ENABLED",
+                                  mediaStorageConfig.pStatus,
+                                  mediaStorageConfig.statusLength );
     TEST_ASSERT_NULL( mediaStorageConfig.pStreamArn );
-    TEST_ASSERT_EQUAL( 0, mediaStorageConfig.streamArnLength );
+    TEST_ASSERT_EQUAL( 0,
+                       mediaStorageConfig.streamArnLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -991,24 +1107,29 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse( void )
 {
     SignalingMediaStorageConfig_t mediaStorageConfig;
     SignalingResult_t result;
-    const char * message =  \
+    const char * message =
+    "{"
+        "\"MediaStorageConfiguration\":"
         "{"
-            "\"MediaStorageConfiguration\":"
-           "{"
-                "\"Status\": \"ENABLED\","
-                "\"StreamARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:stream/test-stream/1234567890123\","
-                "\"Unkown\": \"Unkown Value\""                  /* This will be ignored. */
-            "}"
-        "}";
+            "\"Status\": \"ENABLED\","
+            "\"StreamARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:stream/test-stream/1234567890123\","
+            "\"Unkown\": \"Unkown Value\"" /* This will be ignored. */
+        "}"
+    "}";
     size_t messageLength = strlen( message );
     const char * pExpectedStreamArn = "arn:aws:kinesisvideo:us-west-2:123456789012:stream/test-stream/1234567890123";
 
     result = Signaling_ParseDescribeMediaStorageConfigResponse( message,
-                                                                messageLength, &( mediaStorageConfig ) );
+                                                                messageLength,
+                                                                &( mediaStorageConfig ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL_STRING_LEN( "ENABLED", mediaStorageConfig.pStatus, mediaStorageConfig.statusLength );
+    TEST_ASSERT_EQUAL( strlen( "ENABLED" ),
+                       mediaStorageConfig.statusLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "ENABLED",
+                                  mediaStorageConfig.pStatus,
+                                  mediaStorageConfig.statusLength );
     TEST_ASSERT_EQUAL( strlen( pExpectedStreamArn ),
                        mediaStorageConfig.streamArnLength );
     TEST_ASSERT_EQUAL_STRING_LEN( pExpectedStreamArn,
@@ -2213,11 +2334,11 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse_UnexpectedResponse(
     /*<----------------------------------------------------------------->*/
 
     const char * message2 = "{"
-        "\"Unkown\": ["                                                                      /* Unkown Key */      
+        "\"Unkown\": ["                                                                      /* Unkown Key */
             "{\"Protocol\": \"WSS\", \"ResourceEndpoint\": \"wss://example.com\"},"
             "{\"Protocol\": \"HTTPS\", \"ResourceEndpoint\": \"https://example.com\"},"
             "{\"Protocol\": \"WEBRTC\", \"ResourceEndpoint\": \"webrtc://example.com\"}"
-        "]"                                             
+        "]"
     "}";
     size_t messageLength2 = strlen( message2 );
 
@@ -2675,15 +2796,15 @@ void test_signaling_ParseGetIceServerConfigResponse_UnexpectedResponse( void )
     /*<----------------------------------------------------------------->*/
 
     const char * message2 = "{"
-        "\"Unkown\": ["                  /* Unkown Key */  
+        "\"Unkown\": ["                  /* Unkown Key */
             "{"
                 "\"Password\": \"password123\","
                 "\"Ttl\": 300,"
                 "\"Uris\": [\"turn:example.com:3478\"],"
                 "\"Username\": \"username123\""
             "}"
-        "]"     
-    "}";              
+        "]"
+    "}";
     size_t messageLength2 = strlen( message2 );
 
 

--- a/test/unit-test/signaling_api/signaling_api_utest.c
+++ b/test/unit-test/signaling_api/signaling_api_utest.c
@@ -44,7 +44,7 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_BadParams( void )
                        result );
 
     awsRegion.pAwsRegion = "us-east-1";
-    awsRegion.awsRegionLength = sizeof( awsRegion.pAwsRegion );
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
     result = Signaling_ConstructDescribeSignalingChannelRequest( &( awsRegion ),
                                                                  NULL, &( requestBuffer ) );
 
@@ -64,14 +64,1179 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    requestBuffer.pUrl = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
-    requestBuffer.urlLength = sizeof( requestBuffer.pUrl );
+    requestBuffer.pUrl = "https://kinesisvideo.cn-east-1.amazonaws.com.cn/describeSignalingChannel";
+    requestBuffer.urlLength = strlen( requestBuffer.pUrl );
     requestBuffer.pBody = NULL;
     result = Signaling_ConstructDescribeSignalingChannelRequest( &( awsRegion ),
                                                                  &( channelName ), &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Describe Channel Request functionality.
+ */
+void test_signaling_ConstructDescribeSignalingChannelRequest( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    SignalingChannelName_t channelName = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 100 ];
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    channelName.pChannelName = "Test-Channel";
+    channelName.channelNameLength = strlen( channelName.pChannelName );
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructDescribeSignalingChannelRequest( &( awsRegion ),
+                                                                 &( channelName ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL_STRING( "https://kinesisvideo.us-east-1.amazonaws.com/describeSignalingChannel", requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING( "{\"ChannelName\":\"Test-Channel\"}", requestBuffer.pBody );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Describe Channel Request functionality.
+ */
+void test_signaling_ConstructDescribeSignalingChannelRequest_SmallLengthRegion( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    SignalingChannelName_t channelName = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 100 ];
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "ca"; /* The Region Length is < 3 */
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    channelName.pChannelName = "Test-Channel-China";
+    channelName.channelNameLength = strlen( channelName.pChannelName );
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructDescribeSignalingChannelRequest( &( awsRegion ),
+                                                                 &( channelName ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL_STRING( "https://kinesisvideo.ca.amazonaws.com/describeSignalingChannel", requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING( "{\"ChannelName\":\"Test-Channel-China\"}", requestBuffer.pBody );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Describe Channel Request functionality for China Region.
+ */
+void test_signaling_ConstructDescribeSignalingChannelRequest_ChinaRegion( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    SignalingChannelName_t channelName = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 100 ];
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "cn-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    channelName.pChannelName = "Test-Channel-China";
+    channelName.channelNameLength = strlen( channelName.pChannelName );
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructDescribeSignalingChannelRequest( &( awsRegion ),
+                                                                 &( channelName ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL_STRING( "https://kinesisvideo.cn-east-1.amazonaws.com.cn/describeSignalingChannel", requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING( "{\"ChannelName\":\"Test-Channel-China\"}", requestBuffer.pBody );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Describe Channel Request functionality.
+ */
+void test_signaling_ConstructDescribeSignalingChannelRequest_URLOutofMemory( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    SignalingChannelName_t channelName = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 69 ];         /* The url buffer is small */
+    char bodyBuffer[ 100 ];
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    channelName.pChannelName = "Test-Channel";
+    channelName.channelNameLength = strlen( channelName.pChannelName );
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructDescribeSignalingChannelRequest( &( awsRegion ),
+                                                                 &( channelName ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Describe Channel Request functionality.
+ */
+void test_signaling_ConstructDescribeSignalingChannelRequest_BodyOutofMemory( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    SignalingChannelName_t channelName = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 30 ];         /* The body buffer is small */
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    channelName.pChannelName = "Test-Channel";
+    channelName.channelNameLength = strlen( channelName.pChannelName );
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructDescribeSignalingChannelRequest( &( awsRegion ),
+                                                                 &( channelName ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Describe Response fail functionality for Bad Parameters.
+ */
+void test_signaling_ParseDescribeSignalingChannelResponse_BadParams( void )
+{
+    const char message;
+    size_t messageLength = sizeof( message );
+    SignalingChannelInfo_t channelInfo;
+    SignalingResult_t result;
+
+    result = Signaling_ParseDescribeSignalingChannelResponse( NULL,
+                                                              messageLength, &( channelInfo ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    result = Signaling_ParseDescribeSignalingChannelResponse( &( message ),
+                                                              messageLength, NULL );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Describe Response functionality for Invalid JSON.
+ */
+void test_signaling_ParseDescribeSignalingChannelResponse_InvalidJson( void )
+{
+    const char * message = "{\"ChannelInfo\": {";        /* Missing Closing Braces */
+    size_t messageLength = strlen( message );
+    SignalingChannelInfo_t channelInfo;
+    SignalingResult_t result;
+
+    result = Signaling_ParseDescribeSignalingChannelResponse( message,
+                                                              messageLength, &( channelInfo ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
+                       result );
+
+    /* <--------------------------------------------------------------------> */
+
+    const char *message2 = "{"
+        "\"ChannelInfo\": {"
+            "\"SingleMasterConfiguration\": \"InvalidValue\""
+        "}"
+    "}";
+    size_t messageLength2 = strlen( message2 );
+
+    result = Signaling_ParseDescribeSignalingChannelResponse( message2,
+                                                              messageLength2, &( channelInfo ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+
+/**
+ * @brief Validate Signaling Parse Describe Response functionality for Unexpected Response.
+ */
+void test_signaling_ParseDescribeSignalingChannelResponse_UnexpectedResponse( void )
+{
+    const char * message = "{\"UnexpectedKey\": {}}";            /* The Key is not known */
+    size_t messageLength = strlen( message );
+    SignalingChannelInfo_t channelInfo;
+    SignalingResult_t result;
+
+    result = Signaling_ParseDescribeSignalingChannelResponse( message,
+                                                              messageLength, &( channelInfo ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Describe Response functionality for Invalid TTL.
+ */
+void test_signaling_ParseDescribeSignalingChannelResponse_InvalidTTL_Low( void )
+{
+    SignalingChannelInfo_t channelInfo;
+    SignalingResult_t result;
+    const char *message =  "{"
+        "\"ChannelInfo\": {"
+            "\"SingleMasterConfiguration\": {\"MessageTtlSeconds\": 0}"
+        "}"
+    "}";
+    size_t messageLength = strlen( message );
+
+    result = Signaling_ParseDescribeSignalingChannelResponse( message,
+                                                              messageLength, &( channelInfo ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_TTL,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Describe Response functionality for Invalid TTL.
+ */
+void test_signaling_ParseDescribeSignalingChannelResponse_InvalidTTL_High( void )
+{
+    SignalingChannelInfo_t channelInfo;
+    SignalingResult_t result;
+    const char *message =  "{"
+        "\"ChannelInfo\": {"
+            "\"SingleMasterConfiguration\": {\"MessageTtlSeconds\": 999999999}"
+        "}"
+    "}";
+    size_t messageLength = strlen( message );
+
+    result = Signaling_ParseDescribeSignalingChannelResponse( message,
+                                                              messageLength, &( channelInfo ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_TTL,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Describe Response functionality for Invalid Channel Type.
+ */
+void test_signaling_ParseDescribeSignalingChannelResponse_InvalidChannel_Type( void )
+{
+    SignalingChannelInfo_t channelInfo;
+    SignalingResult_t result;
+    const char *message = "{"
+        "\"ChannelInfo\": {"
+            "\"ChannelType\": \"INVALID_TYPE\""
+        "}"
+    "}";
+    size_t messageLength = strlen( message );
+
+    result = Signaling_ParseDescribeSignalingChannelResponse( message,
+                                                              messageLength, &( channelInfo ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_CHANNEL_TYPE,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Describe Response functionality for Invalid Channel Name.
+ */
+void test_signaling_ParseDescribeSignalingChannelResponse_InvalidChannel_Name( void )
+{   
+    SignalingChannelInfo_t channelInfo;
+    SignalingResult_t result;
+
+    char longChannelName[ SIGNALING_CHANNEL_NAME_MAX_LEN + 10 ];
+    memset( longChannelName, 'a', sizeof( longChannelName ) - 1 );
+    longChannelName[ sizeof( longChannelName ) - 1 ] = '\0';
+    char message[ 1000 ];
+    snprintf(message, sizeof(message), "{"
+        "\"ChannelInfo\": {"
+            "\"ChannelName\": \"%s\""
+        "}"
+    "}", longChannelName);
+    size_t messageLength = strlen( message );
+
+    result = Signaling_ParseDescribeSignalingChannelResponse( message,
+                                                              messageLength, &( channelInfo ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_CHANNEL_NAME,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Describe Response functionality.
+ */
+void test_signaling_ParseDescribeSignalingChannelResponse( void )
+{
+    SignalingChannelInfo_t channelInfo;
+    SignalingResult_t result;
+    const char *message = "{"
+        "\"ChannelInfo\": {"
+            "\"ChannelARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123\","
+            "\"ChannelName\": \"test-channel\","
+            "\"ChannelStatus\": \"ACTIVE\","
+            "\"ChannelType\": \"SINGLE_MASTER\","
+            "\"CreationTime\": \"2023-05-01T12:00:00Z\","
+            "\"SingleMasterConfiguration\": {\"MessageTtlSeconds\": 60},"
+            "\"Version\": \"1\""
+        "}"
+    "}";
+    size_t messageLength = strlen( message );
+
+    result = Signaling_ParseDescribeSignalingChannelResponse( message,
+                                                              messageLength, &( channelInfo ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL_STRING_LEN( "arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123",
+                                  channelInfo.channelArn.pChannelArn,
+                                  channelInfo.channelArn.channelArnLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "test-channel",
+                                  channelInfo.channelName.pChannelName,
+                                  channelInfo.channelName.channelNameLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "ACTIVE", channelInfo.pChannelStatus, channelInfo.channelStatusLength );
+    TEST_ASSERT_EQUAL( SIGNALING_TYPE_CHANNEL_SINGLE_MASTER, channelInfo.channelType );
+    TEST_ASSERT_EQUAL( 60, channelInfo.messageTtlSeconds );
+    TEST_ASSERT_EQUAL_STRING_LEN( "1", channelInfo.pVersion, channelInfo.versionLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Describe Media Storage Config Request fail functionality for Bad Parameters.
+ */
+void test_signaling_ConstructDescribeMediaStorageConfigRequest_BadParams( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    SignalingChannelArn_t channelArn = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
+
+    result = Signaling_ConstructDescribeMediaStorageConfigRequest( NULL,
+                                                                   &( channelArn ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    awsRegion.pAwsRegion = NULL;
+    result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
+                                                                   &( channelArn ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+    result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
+                                                                   NULL, &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
+                                                                   &( channelArn ), NULL );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    requestBuffer.pUrl = NULL;
+    result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
+                                                                   &( channelArn ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    requestBuffer.pUrl = "https://kinesisvideo.cn-east-1.amazonaws.com.cn/describeSignalingChannel";
+    requestBuffer.urlLength = strlen( requestBuffer.pUrl );
+    requestBuffer.pBody = NULL;
+    result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
+                                                                   &( channelArn ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    requestBuffer.pBody = "{\"ChannelName\":\"Test-Channel-China\"}";
+    requestBuffer.bodyLength = strlen( requestBuffer.pBody );
+    channelArn.pChannelArn = NULL;
+    result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
+                                                                   &( channelArn ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Describe Media Storage Config Request functionality.
+ */
+void test_signaling_ConstructDescribeMediaStorageConfigRequest( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    SignalingChannelArn_t channelArn = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 100 ];
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    channelArn.pChannelArn = "arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123";
+    channelArn.channelArnLength = strlen( channelArn.pChannelArn );
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
+                                                                   &( channelArn ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL_STRING( "https://kinesisvideo.us-east-1.amazonaws.com/describeMediaStorageConfiguration", requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING( "{\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\"}", requestBuffer.pBody );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Describe Media Storage Config Request functionality.
+ */
+void test_signaling_ConstructDescribeMediaStorageConfigRequest_SmallLengthRegion( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    SignalingChannelArn_t channelArn = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 100 ];
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "ca"; /* The Region Length is < 3 */
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    channelArn.pChannelArn = "arn:aws:kinesisvideo:ca:123456789012:channel/test-channel/1234567890123";
+    channelArn.channelArnLength = strlen( channelArn.pChannelArn );
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
+                                                                   &( channelArn ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL_STRING( "https://kinesisvideo.ca.amazonaws.com/describeMediaStorageConfiguration", requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING( "{\"ChannelARN\":\"arn:aws:kinesisvideo:ca:123456789012:channel/test-channel/1234567890123\"}", requestBuffer.pBody );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Describe Media Storage Config Request functionality for China Region.
+ */
+void test_signaling_ConstructDescribeMediaStorageConfigRequest_ChinaRegion( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    SignalingChannelArn_t channelArn = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 100 ];
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "cn-north-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    channelArn.pChannelArn = "arn:aws-cn:kinesisvideo:cn-north-1:123456789012:channel/test-channel/1234567890123";
+    channelArn.channelArnLength = strlen( channelArn.pChannelArn );
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
+                                                                   &( channelArn ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL_STRING( "https://kinesisvideo.cn-north-1.amazonaws.com.cn/describeMediaStorageConfiguration", requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING( "{\"ChannelARN\":\"arn:aws-cn:kinesisvideo:cn-north-1:123456789012:channel/test-channel/1234567890123\"}", requestBuffer.pBody );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Describe Media Storage Config Request functionality.
+ */
+void test_signaling_ConstructDescribeMediaStorageConfigRequest_URLOutOfMemory( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    SignalingChannelArn_t channelArn = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 78 ];     /* The url buffer is small */
+    char bodyBuffer[ 100 ];
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    channelArn.pChannelArn = "arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123";
+    channelArn.channelArnLength = strlen( channelArn.pChannelArn );
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
+                                                                   &( channelArn ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Describe Media Storage Config Request functionality.
+ */
+void test_signaling_ConstructDescribeMediaStorageConfigRequest_BodyOutOfMemory( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    SignalingChannelArn_t channelArn = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 95 ];       /* The body buffer is small */
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    channelArn.pChannelArn = "arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123";
+    channelArn.channelArnLength = strlen( channelArn.pChannelArn );
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructDescribeMediaStorageConfigRequest( &( awsRegion ),
+                                                                   &( channelArn ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Describe Media Storage Config fail functionality for Bad Parameters.
+ */
+void test_signaling_ParseDescribeMediaStorageConfigResponse_BadParams( void )
+{
+    const char * message;
+    size_t messageLength = sizeof( message );
+    SignalingMediaStorageConfig_t mediaStorageConfig;
+    SignalingResult_t result;
+
+    result = Signaling_ParseDescribeMediaStorageConfigResponse( NULL,
+                                                                messageLength, &( mediaStorageConfig ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    result = Signaling_ParseDescribeMediaStorageConfigResponse( message,
+                                                                messageLength, NULL );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Describe Media Storage Config functionality.
+ */
+void test_signaling_ParseDescribeMediaStorageConfigResponse_InvalidJson( void )
+{
+    const char * message = "{\"MediaStorageConfiguration\": {";  /* Missing closing brace */
+    size_t messageLength = sizeof( message );
+    SignalingMediaStorageConfig_t mediaStorageConfig;
+    SignalingResult_t result;
+
+    result = Signaling_ParseDescribeMediaStorageConfigResponse( message,
+                                                                messageLength, &( mediaStorageConfig ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Describe Media Storage Config functionality.
+ */
+void test_signaling_ParseDescribeMediaStorageConfigResponse_UnexpectedResponse( void )
+{
+    const char * message = "{\"UnexpectedKey\": {}}";        /* Unkown Key */
+    size_t messageLength = strlen( message );
+    SignalingMediaStorageConfig_t mediaStorageConfig;
+    SignalingResult_t result;
+
+    result = Signaling_ParseDescribeMediaStorageConfigResponse( message,
+                                                                messageLength, &( mediaStorageConfig ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Describe Media Storage Config functionality.
+ */
+void test_signaling_ParseDescribeMediaStorageConfigResponse_MissingFields( void )
+{
+    SignalingMediaStorageConfig_t mediaStorageConfig;
+    SignalingResult_t result;
+    const char *message = "{"
+        "\"MediaStorageConfiguration\": {"
+            "\"Status\": \"ENABLED\""
+            // Missing StreamARN
+        "}"
+    "}";
+    size_t messageLength = strlen( message );
+
+    result = Signaling_ParseDescribeMediaStorageConfigResponse( message,
+                                                                messageLength, &( mediaStorageConfig ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK, result );
+    TEST_ASSERT_EQUAL_STRING_LEN( "ENABLED", mediaStorageConfig.pStatus, mediaStorageConfig.statusLength );
+    TEST_ASSERT_NULL( mediaStorageConfig.pStreamArn );
+    TEST_ASSERT_EQUAL( 0, mediaStorageConfig.streamArnLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Describe Media Storage Config functionality.
+ */
+void test_signaling_ParseDescribeMediaStorageConfigResponse( void )
+{
+    SignalingMediaStorageConfig_t mediaStorageConfig;
+    SignalingResult_t result;
+    const char *message  = "{"
+            "\"MediaStorageConfiguration\": {"
+            "\"Status\": \"ENABLED\","
+            "\"StreamARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:stream/test-stream/1234567890123\""
+            "}"
+            "}";
+    size_t messageLength = strlen( message );
+
+    result = Signaling_ParseDescribeMediaStorageConfigResponse( message,
+                                                                messageLength, &( mediaStorageConfig ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL_STRING_LEN( "ENABLED", mediaStorageConfig.pStatus, mediaStorageConfig.statusLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "arn:aws:kinesisvideo:us-west-2:123456789012:stream/test-stream/1234567890123",
+                                  mediaStorageConfig.pStreamArn,
+                                  mediaStorageConfig.streamArnLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Channel Request fail functionality for Bad Parameters.
+ */
+void test_signaling_ConstructCreateSignalingChannelRequest_BadParams( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
+    SignalingTag_t tags[ 2 ] = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
+
+    result = Signaling_ConstructCreateSignalingChannelRequest( NULL,
+                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    awsRegion.pAwsRegion = NULL;
+    result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
+                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+    result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
+                                                               NULL, &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
+                                                               &( createSignalingChannelRequestInfo ), NULL );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    requestBuffer.pUrl = NULL;
+    result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
+                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    requestBuffer.pUrl = "https://kinesisvideo.cn-east-1.amazonaws.com.cn/describeSignalingChannel";
+    requestBuffer.urlLength = strlen( requestBuffer.pUrl );
+    requestBuffer.pBody = NULL;
+
+    result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
+                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    requestBuffer.pBody = "{\"ChannelName\":\"Test-Channel-China\"}";
+    requestBuffer.bodyLength = strlen( requestBuffer.pBody );
+    createSignalingChannelRequestInfo.numTags = 1;
+    createSignalingChannelRequestInfo.pTags = NULL;
+
+    result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
+                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    createSignalingChannelRequestInfo.pTags = &( tags[ 0 ] );
+    createSignalingChannelRequestInfo.channelName.channelNameLength = SIGNALING_CHANNEL_NAME_MAX_LEN + 1;
+    result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
+                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Channel Request functionality.
+ */
+void test_signaling_ConstructCreateSignalingChannelRequest( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 500 ];
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    createSignalingChannelRequestInfo.channelName.pChannelName = "Test-Channel";
+    createSignalingChannelRequestInfo.channelName.channelNameLength = strlen( createSignalingChannelRequestInfo.channelName.pChannelName );
+    createSignalingChannelRequestInfo.channelType = SIGNALING_TYPE_CHANNEL_SINGLE_MASTER;
+    createSignalingChannelRequestInfo.messageTtlSeconds = 60;
+    createSignalingChannelRequestInfo.numTags = 0;
+    createSignalingChannelRequestInfo.pTags = NULL;
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
+                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL_STRING( "https://kinesisvideo.us-east-1.amazonaws.com/createSignalingChannel", requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING( "{\"ChannelName\":\"Test-Channel\",\"ChannelType\":\"SINGLE_MASTER\",\"SingleMasterConfiguration\":{\"MessageTtlSeconds\":60}}", requestBuffer.pBody );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Channel Request functionality.
+ */
+void test_signaling_ConstructCreateSignalingChannelRequest_SmallLengthRegion( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 500 ];
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "ca";            /* The Region Length is < 3 */
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    createSignalingChannelRequestInfo.channelName.pChannelName = "Test-Channel";
+    createSignalingChannelRequestInfo.channelName.channelNameLength = strlen( createSignalingChannelRequestInfo.channelName.pChannelName );
+    createSignalingChannelRequestInfo.channelType = SIGNALING_TYPE_CHANNEL_SINGLE_MASTER;
+    createSignalingChannelRequestInfo.messageTtlSeconds = 60;
+    createSignalingChannelRequestInfo.numTags = 0;
+    createSignalingChannelRequestInfo.pTags = NULL;
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
+                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL_STRING( "https://kinesisvideo.ca.amazonaws.com/createSignalingChannel", requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING( "{\"ChannelName\":\"Test-Channel\",\"ChannelType\":\"SINGLE_MASTER\",\"SingleMasterConfiguration\":{\"MessageTtlSeconds\":60}}", requestBuffer.pBody );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Channel Request functionality.
+ */
+void test_signaling_ConstructCreateSignalingChannelRequest_ChinaRegion( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 500 ];
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "cn-north-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    createSignalingChannelRequestInfo.channelName.pChannelName = "Test-Channel";
+    createSignalingChannelRequestInfo.channelName.channelNameLength = strlen( createSignalingChannelRequestInfo.channelName.pChannelName );
+    createSignalingChannelRequestInfo.channelType = SIGNALING_TYPE_CHANNEL_SINGLE_MASTER;
+    createSignalingChannelRequestInfo.messageTtlSeconds = 60;
+    createSignalingChannelRequestInfo.numTags = 0;
+    createSignalingChannelRequestInfo.pTags = NULL;
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
+                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL_STRING( "https://kinesisvideo.cn-north-1.amazonaws.com.cn/createSignalingChannel", requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING( "{\"ChannelName\":\"Test-Channel\",\"ChannelType\":\"SINGLE_MASTER\",\"SingleMasterConfiguration\":{\"MessageTtlSeconds\":60}}", requestBuffer.pBody );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Channel Request functionality.
+ */
+void test_signaling_ConstructCreateSignalingChannelRequest_WithTags( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
+    SignalingTag_t tags[ 1 ] = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 500 ];
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    tags->pName = "Tag1";
+    tags->nameLength = strlen( tags->pName );
+    tags->pValue = "Value1";
+    tags->valueLength = strlen( tags->pValue );
+
+    createSignalingChannelRequestInfo.channelName.pChannelName = "Test-Channel";
+    createSignalingChannelRequestInfo.channelName.channelNameLength = strlen( createSignalingChannelRequestInfo.channelName.pChannelName );
+    createSignalingChannelRequestInfo.channelType = SIGNALING_TYPE_CHANNEL_SINGLE_MASTER;
+    createSignalingChannelRequestInfo.messageTtlSeconds = 60;
+    createSignalingChannelRequestInfo.numTags = 1;
+    createSignalingChannelRequestInfo.pTags = tags;
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
+                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL_STRING( "https://kinesisvideo.us-east-1.amazonaws.com/createSignalingChannel", requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING( "{\"ChannelName\":\"Test-Channel\",\"ChannelType\":\"SINGLE_MASTER\",\"SingleMasterConfiguration\":{\"MessageTtlSeconds\":60}"",\"Tags\":[{\"Key\":\"Tag1\",\"Value\":\"Value1\"}]}", requestBuffer.pBody );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Describe Media Storage Config fail functionality for Bad Parameters.
+ */
+void test_signaling_ParseCreateSignalingChannelResponse_BadParams( void )
+{
+    const char * message;
+    size_t messageLength = sizeof( message );
+    SignalingChannelArn_t channelArn = { 0 };
+    SignalingResult_t result;
+
+    result = Signaling_ParseCreateSignalingChannelResponse( NULL,
+                                                            messageLength, &( channelArn ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    result = Signaling_ParseCreateSignalingChannelResponse( message,
+                                                            messageLength, NULL );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Create Signaling Channel Response functionality.
+ */
+void test_signaling_ParseCreateSignalingChannelResponse_InvalidJson( void )
+{
+    const char * message = "{\"ChannelARN\": \"test-arn\"";  /* Missing closing brace */
+    size_t messageLength = strlen( message );
+    SignalingChannelArn_t channelArn = { 0 };
+    SignalingResult_t result;
+
+    result = Signaling_ParseCreateSignalingChannelResponse( message,
+                                                            messageLength, &( channelArn ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Create Signaling Channel Response functionality.
+ */
+void test_signaling_ParseCreateSignalingChannelResponse_UnexpectedResponse( void )
+{
+    const char * message = "{}";
+    size_t messageLength = strlen( message );
+    SignalingChannelArn_t channelArn = { 0 };
+    SignalingResult_t result;
+
+    result = Signaling_ParseCreateSignalingChannelResponse( message,
+                                                            messageLength, &( channelArn ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Create Signaling Channel Response functionality.
+ */
+void test_signaling_ParseCreateSignalingChannelResponse( void )
+{
+    const char *message = "{"
+        "\"ChannelARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123\""
+    "}";
+    size_t messageLength = strlen( message );
+    SignalingChannelArn_t channelArn = { 0 };
+    SignalingResult_t result;
+
+    result = Signaling_ParseCreateSignalingChannelResponse( message,
+                                                            messageLength, &( channelArn ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL_STRING_LEN( "arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123",
+                                  channelArn.pChannelArn,
+                                  channelArn.channelArnLength );
+    TEST_ASSERT_EQUAL( 78, channelArn.channelArnLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Get Channel Endpoint Request fail functionality for Bad Parameters.
+ */
+void test_signaling_ConstructGetSignalingChannelEndpointRequest_BadParams( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    GetSignalingChannelEndpointRequestInfo_t getSignalingChannelEndPointRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char channelArn[] = "arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123";
+    SignalingResult_t result;
+
+    result = Signaling_ConstructGetSignalingChannelEndpointRequest( NULL,
+                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    awsRegion.pAwsRegion = NULL;
+    result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
+                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+    result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
+                                                                    NULL, &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
+                                                                    &( getSignalingChannelEndPointRequestInfo ), NULL );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    requestBuffer.pUrl = NULL;
+    result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
+                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    requestBuffer.pUrl = "https://kinesisvideo.cn-east-1.amazonaws.com.cn/describeSignalingChannel";
+    requestBuffer.urlLength = strlen( requestBuffer.pUrl );
+    requestBuffer.pBody = NULL;
+    result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
+                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    requestBuffer.pBody = "{\"ChannelName\":\"Test-Channel\"}";
+    requestBuffer.bodyLength = strlen( requestBuffer.pBody );
+    getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn = NULL;
+    result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
+                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn = &( channelArn[ 0 ] );
+    getSignalingChannelEndPointRequestInfo.channelArn.channelArnLength = strlen( getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn );
+    getSignalingChannelEndPointRequestInfo.role = SIGNALING_ROLE_NONE;
+    result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
+                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Get Channel Endpoint Request functionality .
+ */
+void test_signaling_ConstructGetSignalingChannelEndpointRequest( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    GetSignalingChannelEndpointRequestInfo_t getSignalingChannelEndPointRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 500 ];
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn = "arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123";
+    getSignalingChannelEndPointRequestInfo.channelArn.channelArnLength = strlen( getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn );
+    getSignalingChannelEndPointRequestInfo.role = SIGNALING_ROLE_MASTER;
+    getSignalingChannelEndPointRequestInfo.protocols = SIGNALING_PROTOCOL_HTTPS;
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
+                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL_STRING( "https://kinesisvideo.us-east-1.amazonaws.com/getSignalingChannelEndpoint", requestBuffer.pUrl );
+    TEST_ASSERT_TRUE( strstr( requestBuffer.pBody, "\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\"" ) != NULL );
+    TEST_ASSERT_TRUE( strstr( requestBuffer.pBody, "\"Protocols\":[\"HTTPS\"]" ) != NULL );
+    TEST_ASSERT_TRUE( strstr( requestBuffer.pBody, "\"Role\":\"MASTER\"" ) != NULL );
 }
 
 /*-----------------------------------------------------------*/

--- a/test/unit-test/signaling_api/signaling_api_utest.c
+++ b/test/unit-test/signaling_api/signaling_api_utest.c
@@ -1698,7 +1698,7 @@ void test_signaling_ParseCreateSignalingChannelResponse_Unkown( void )
     result = Signaling_ParseCreateSignalingChannelResponse( message,
                                                             messageLength, &( channelArn ) );
 
-    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
     TEST_ASSERT_EQUAL( 0, channelArn.pChannelArn );
     TEST_ASSERT_EQUAL( 0, channelArn.channelArnLength );

--- a/test/unit-test/signaling_api/signaling_api_utest.c
+++ b/test/unit-test/signaling_api/signaling_api_utest.c
@@ -415,7 +415,7 @@ void test_signaling_ParseDescribeSignalingChannelResponse_UnexpectedResponse( vo
 
     const char * message2 =
     "{"
-        "\"Unkown\":" /* Unexpected key. */
+        "\"Unknown\":" /* Unexpected key. */
         "{"
             "\"ChannelARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123\""
         "}"
@@ -612,7 +612,7 @@ void test_signaling_ParseDescribeSignalingChannelResponse( void )
             "\"CreationTime\": \"2023-05-01T12:00:00Z\","
             "\"SingleMasterConfiguration\": {\"MessageTtlSeconds\": 60},"
             "\"Version\": \"1\","
-            "\"Unkown\": \"200\"" /* Unkown Tag --> Will be skipped. */
+            "\"Unknown\": \"200\"" /* Unknown Tag --> Will be skipped. */
         "}"
     "}";
     size_t messageLength = strlen( message );
@@ -1027,7 +1027,7 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse_UnexpectedResponse( 
 
     const char * message2 =
     "{"
-        "\"Unkown\":" /* Unkown Key. */
+        "\"Unknown\":" /* Unknown Key. */
         "{"
             "\"Status\": \"ENABLED\","
             "\"StreamARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:stream/test-stream/1234567890123\""
@@ -1113,7 +1113,7 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse( void )
         "{"
             "\"Status\": \"ENABLED\","
             "\"StreamARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:stream/test-stream/1234567890123\","
-            "\"Unkown\": \"Unkown Value\"" /* This will be ignored. */
+            "\"Unknown\": \"Unknown Value\"" /* This will be ignored. */
         "}"
     "}";
     size_t messageLength = strlen( message );
@@ -1399,7 +1399,7 @@ void test_signaling_ConstructCreateSignalingChannelRequest( void )
 /**
  * @brief Validate Signaling Construct Channel Request functionality.
  */
-void test_signaling_ConstructCreateSignalingChannelRequest_UnkownChannelType( void )
+void test_signaling_ConstructCreateSignalingChannelRequest_UnknownChannelType( void )
 {
     SignalingAwsRegion_t awsRegion = { 0 };
     CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
@@ -1855,13 +1855,13 @@ void test_signaling_ParseCreateSignalingChannelResponse_UnexpectedResponse( void
 /**
  * @brief Validate Signaling Parse Create Signaling Channel Response functionality.
  */
-void test_signaling_ParseCreateSignalingChannelResponse_UnkownKey( void )
+void test_signaling_ParseCreateSignalingChannelResponse_UnknownKey( void )
 {
     SignalingChannelArn_t channelArn = { 0 };
     SignalingResult_t result;
     const char * message =
     "{"
-        "\"Unkown\": \"arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123\""
+        "\"Unknown\": \"arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123\""
     "}";
     size_t messageLength = strlen( message );
 
@@ -2426,7 +2426,7 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse_UnexpectedResponse(
 
     const char * message2 =
     "{"
-        "\"Unkown\":" /* Unkown key. */
+        "\"Unknown\":" /* Unknown key. */
         "["
             "{\"Protocol\": \"WSS\", \"ResourceEndpoint\": \"wss://example.com\"},"
             "{\"Protocol\": \"HTTPS\", \"ResourceEndpoint\": \"https://example.com\"},"
@@ -2563,8 +2563,8 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse( void )
             "{\"Protocol\": \"WSS\", \"ResourceEndpoint\": \"wss://example.com\"},"
             "{\"Protocol\": \"HTTPS\", \"ResourceEndpoint\": \"https://example.com\"},"
             "{\"Protocol\": \"WEBRTC\", \"ResourceEndpoint\": \"webrtc://example.com\"},"
-            "{\"Unkown\": \"WEBRTC\", \"ResourceEndpoint\": \"webrtc://example.com\"},"      /* Unkown Tag is ignored. */
-            "{\"Protocol\": \"WEBRTC\", \"Unkown\": \"webrtc://example.com\"}"               /* Unkown Tag is ignored. */
+            "{\"Unknown\": \"WEBRTC\", \"ResourceEndpoint\": \"webrtc://example.com\"},"      /* Unknown Tag is ignored. */
+            "{\"Protocol\": \"WEBRTC\", \"Unknown\": \"webrtc://example.com\"}"               /* Unknown Tag is ignored. */
         "]"
     "}";
     size_t messageLength = strlen( message );
@@ -2961,7 +2961,7 @@ void test_signaling_ParseGetIceServerConfigResponse_UnexpectedResponse( void )
 
     const char * message2 =
     "{"
-        "\"Unkown\":" /* Unkown key. */
+        "\"Unknown\":" /* Unknown key. */
         "["
             "{"
                 "\"Password\": \"password123\","
@@ -2983,7 +2983,7 @@ void test_signaling_ParseGetIceServerConfigResponse_UnexpectedResponse( void )
 
     /*<----------------------------------------------------------------->*/
 
-    const char * message3 = "{\"UnexpectedKey\": []}"; /* Unkown Key Though the length of "IceServerList" == "UnexpectedKey". */
+    const char * message3 = "{\"UnexpectedKey\": []}"; /* Unknown Key Though the length of "IceServerList" == "UnexpectedKey". */
     size_t messageLength3 = strlen( message3 );
 
     result = Signaling_ParseGetIceServerConfigResponse( message3,
@@ -3113,7 +3113,7 @@ void test_signaling_ParseGetIceServerConfigResponse( void )
                 "\"Ttl\": 300,"
                 "\"Uris\": [\"turn:example.com:3478\"],"
                 "\"Username\": \"username123\","
-                "\"Unkown\": \"Unkown-Value\"" /* This Unkown Tag will be ignored. */
+                "\"Unknown\": \"Unknown-Value\"" /* This Unknown Tag will be ignored. */
             "}"
         "]"
     "}";
@@ -3555,14 +3555,15 @@ void test_signaling_ConstructDeleteSignalingChannelRequest( void )
     SignalingAwsRegion_t awsRegion = { 0 };
     DeleteSignalingChannelRequestInfo_t deleteSignalingChannelRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
     char urlBuffer[ 200 ];
     char bodyBuffer[ 500 ];
-    SignalingResult_t result;
     const char * pExpectedUrl = "https://kinesisvideo.us-east-1.amazonaws.com/deleteSignalingChannel";
-    const char * pExpectedBody = "{"
-                                    "\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\","
-                                    "\"CurrentVersion\":\"1.0.0\""
-                                  "}";
+    const char * pExpectedBody =
+    "{"
+        "\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\","
+        "\"CurrentVersion\":\"1.0.0\""
+    "}";
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -3578,18 +3579,21 @@ void test_signaling_ConstructDeleteSignalingChannelRequest( void )
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
-                                                               &( deleteSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( deleteSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
                        requestBuffer.urlLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
-                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
+                                  requestBuffer.pUrl,
+                                  requestBuffer.urlLength );
     TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
                        requestBuffer.bodyLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
-                              requestBuffer.pBody );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedBody,
+                                  requestBuffer.pBody,
+                                  requestBuffer.bodyLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -3602,14 +3606,15 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_ChinaRegion( void )
     SignalingAwsRegion_t awsRegion = { 0 };
     DeleteSignalingChannelRequestInfo_t deleteSignalingChannelRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
     char urlBuffer[ 200 ];
     char bodyBuffer[ 500 ];
-    SignalingResult_t result;
     const char * pExpectedUrl = "https://kinesisvideo.cn-north-1.amazonaws.com.cn/deleteSignalingChannel";
-    const char * pExpectedBody = "{"
-                                    "\"ChannelARN\":\"arn:aws-cn:kinesisvideo:cn-north-1:123456789012:channel/test-channel/1234567890123\","
-                                    "\"CurrentVersion\":\"2.0.0\""
-                                  "}";
+    const char * pExpectedBody =
+    "{"
+        "\"ChannelARN\":\"arn:aws-cn:kinesisvideo:cn-north-1:123456789012:channel/test-channel/1234567890123\","
+        "\"CurrentVersion\":\"2.0.0\""
+    "}";
 
     awsRegion.pAwsRegion = "cn-north-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -3625,18 +3630,21 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_ChinaRegion( void )
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
-                                                               &( deleteSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( deleteSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
                        requestBuffer.urlLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
-                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
+                                  requestBuffer.pUrl,
+                                  requestBuffer.urlLength );
     TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
                        requestBuffer.bodyLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
-                              requestBuffer.pBody );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedBody,
+                                  requestBuffer.pBody,
+                                  requestBuffer.bodyLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -3649,16 +3657,17 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_SmallLengthRegion( vo
     SignalingAwsRegion_t awsRegion = { 0 };
     DeleteSignalingChannelRequestInfo_t deleteSignalingChannelRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
     char urlBuffer[ 200 ];
     char bodyBuffer[ 500 ];
-    SignalingResult_t result;
     const char * pExpectedUrl = "https://kinesisvideo.ca.amazonaws.com/deleteSignalingChannel";
-    const char * pExpectedBody = "{"
-                                    "\"ChannelARN\":\"arn:aws:kinesisvideo:ca:123456789012:channel/test-channel/1234567890123\","
-                                    "\"CurrentVersion\":\"2.0.0\""
-                                  "}";
+    const char * pExpectedBody =
+    "{"
+        "\"ChannelARN\":\"arn:aws:kinesisvideo:ca:123456789012:channel/test-channel/1234567890123\","
+        "\"CurrentVersion\":\"2.0.0\""
+    "}";
 
-    awsRegion.pAwsRegion = "ca";            /* The Region Length is < 3 */
+    awsRegion.pAwsRegion = "ca"; /* The Region Length is < 3. */
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
 
     deleteSignalingChannelRequestInfo.channelArn.pChannelArn = "arn:aws:kinesisvideo:ca:123456789012:channel/test-channel/1234567890123";
@@ -3672,18 +3681,21 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_SmallLengthRegion( vo
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
-                                                               &( deleteSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( deleteSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
                        requestBuffer.urlLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
-                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
+                                  requestBuffer.pUrl,
+                                  requestBuffer.urlLength );
     TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
                        requestBuffer.bodyLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
-                              requestBuffer.pBody );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedBody,
+                                  requestBuffer.pBody,
+                                  requestBuffer.bodyLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -3691,14 +3703,14 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_SmallLengthRegion( vo
 /**
  * @brief Validate Signaling Construct Delete Signaling Channel Request functionality.
  */
-void test_signaling_ConstructDeleteSignalingChannelRequest_URL_OutofMemory( void )
+void test_signaling_ConstructDeleteSignalingChannelRequest_UrlOutofMemory( void )
 {
     SignalingAwsRegion_t awsRegion = { 0 };
     DeleteSignalingChannelRequestInfo_t deleteSignalingChannelRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
-    char urlBuffer[ 20 ];                   /* The url buffer is small */
-    char bodyBuffer[ 500 ];
     SignalingResult_t result;
+    char urlBuffer[ 20 ]; /* The url buffer is too small to fit the complete URL. */
+    char bodyBuffer[ 500 ];
 
     awsRegion.pAwsRegion = "cn-north-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -3714,7 +3726,8 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_URL_OutofMemory( void
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
-                                                               &( deleteSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( deleteSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
                        result );
@@ -3725,13 +3738,13 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_URL_OutofMemory( void
 /**
  * @brief Validate Signaling Construct Delete Signaling Channel Request functionality.
  */
-void test_signaling_ConstructDeleteSignalingChannelRequest_Body_OutofMemory( void )
+void test_signaling_ConstructDeleteSignalingChannelRequest_BodyOutofMemory( void )
 {
     SignalingAwsRegion_t awsRegion = { 0 };
     DeleteSignalingChannelRequestInfo_t deleteSignalingChannelRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
     char urlBuffer[ 200 ];
-    char bodyBuffer[ 50 ];              /* The body buffer is small */
+    char bodyBuffer[ 50 ]; /* The body buffer is too small to fit the complete body. */
     SignalingResult_t result;
 
     awsRegion.pAwsRegion = "cn-north-1";
@@ -3748,7 +3761,8 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_Body_OutofMemory( voi
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
-                                                               &( deleteSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( deleteSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
                        result );
@@ -3767,7 +3781,8 @@ void test_signaling_ConstructConnectWssEndpointRequest_BadParams( void )
     SignalingResult_t result;
 
     result = Signaling_ConstructConnectWssEndpointRequest( NULL,
-                                                           &( connectWssEndpointRequestInfo ), &( requestBuffer ) );
+                                                           &( connectWssEndpointRequestInfo ),
+                                                           &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -3775,8 +3790,10 @@ void test_signaling_ConstructConnectWssEndpointRequest_BadParams( void )
     /*      <------------------------------------------------------------------------------------------>      */
 
     wssEndpoint.pEndpoint = NULL;
+
     result = Signaling_ConstructConnectWssEndpointRequest( &( wssEndpoint ),
-                                                           &( connectWssEndpointRequestInfo ), &( requestBuffer ) );
+                                                           &( connectWssEndpointRequestInfo ),
+                                                           &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -3787,7 +3804,8 @@ void test_signaling_ConstructConnectWssEndpointRequest_BadParams( void )
     wssEndpoint.endpointLength = strlen( wssEndpoint.pEndpoint );
 
     result = Signaling_ConstructConnectWssEndpointRequest( &( wssEndpoint ),
-                                                           &( connectWssEndpointRequestInfo ), NULL );
+                                                           &( connectWssEndpointRequestInfo ),
+                                                           NULL );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -3797,15 +3815,19 @@ void test_signaling_ConstructConnectWssEndpointRequest_BadParams( void )
 
 
     result = Signaling_ConstructConnectWssEndpointRequest( &( wssEndpoint ),
-                                                           NULL, &( requestBuffer ) );
+                                                           NULL,
+                                                           &( requestBuffer ) );
+
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     /*      <------------------------------------------------------------------------------------------>      */
 
     requestBuffer.pUrl = NULL;
+
     result = Signaling_ConstructConnectWssEndpointRequest( &( wssEndpoint ),
-                                                           &( connectWssEndpointRequestInfo ), &( requestBuffer ) );
+                                                           &( connectWssEndpointRequestInfo ),
+                                                           &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -3817,7 +3839,8 @@ void test_signaling_ConstructConnectWssEndpointRequest_BadParams( void )
     connectWssEndpointRequestInfo.channelArn.pChannelArn = NULL;
 
     result = Signaling_ConstructConnectWssEndpointRequest( &( wssEndpoint ),
-                                                           &( connectWssEndpointRequestInfo ), &( requestBuffer ) );
+                                                           &( connectWssEndpointRequestInfo ),
+                                                           &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -3829,7 +3852,8 @@ void test_signaling_ConstructConnectWssEndpointRequest_BadParams( void )
     connectWssEndpointRequestInfo.role = SIGNALING_ROLE_NONE;
 
     result = Signaling_ConstructConnectWssEndpointRequest( &( wssEndpoint ),
-                                                           &( connectWssEndpointRequestInfo ), &( requestBuffer ) );
+                                                           &( connectWssEndpointRequestInfo ),
+                                                           &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -3840,7 +3864,8 @@ void test_signaling_ConstructConnectWssEndpointRequest_BadParams( void )
     connectWssEndpointRequestInfo.pClientId = NULL;
 
     result = Signaling_ConstructConnectWssEndpointRequest( &( wssEndpoint ),
-                                                           &( connectWssEndpointRequestInfo ), &( requestBuffer ) );
+                                                           &( connectWssEndpointRequestInfo ),
+                                                           &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -3849,15 +3874,15 @@ void test_signaling_ConstructConnectWssEndpointRequest_BadParams( void )
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate Signaling Construct Connect Web-Sockets Endpoint Request fail functionality for Bad Parameters.
+ * @brief Validate Signaling Construct Connect Web-Sockets Endpoint Request functionality for Master.
  */
 void test_signaling_ConstructConnectWssEndpointRequest_Master( void )
 {
     SignalingChannelEndpoint_t wssEndpoint = { 0 };
     ConnectWssEndpointRequestInfo_t connectWssEndpointRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
-    char urlBuffer[ 300 ];
     SignalingResult_t result;
+    char urlBuffer[ 300 ];
     const char * pExpectedUrl = "wss://example.com?X-Amz-ChannelARN=arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123";
 
     wssEndpoint.pEndpoint = "wss://example.com";
@@ -3875,29 +3900,31 @@ void test_signaling_ConstructConnectWssEndpointRequest_Master( void )
     requestBuffer.bodyLength = 0;
 
     result = Signaling_ConstructConnectWssEndpointRequest( &( wssEndpoint ),
-                                                           &( connectWssEndpointRequestInfo ), &( requestBuffer ) );
+                                                           &( connectWssEndpointRequestInfo ),
+                                                           &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_TRUE( strstr( requestBuffer.pUrl, "X-Amz-ClientId" ) == NULL );
+    TEST_ASSERT_NULL( strstr( requestBuffer.pUrl, "X-Amz-ClientId" ) );
     TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
                        requestBuffer.urlLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
-                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
+                                  requestBuffer.pUrl,
+                                  requestBuffer.urlLength );
 }
 
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate Signaling Construct Connect Web-Sockets Endpoint Request fail functionality for Bad Parameters.
+ * @brief Validate Signaling Construct Connect Web-Sockets Endpoint Request functionality for Viewer.
  */
 void test_signaling_ConstructConnectWssEndpointRequest_Viewer( void )
 {
     SignalingChannelEndpoint_t wssEndpoint = { 0 };
     ConnectWssEndpointRequestInfo_t connectWssEndpointRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
-    char urlBuffer[ 300 ];
     SignalingResult_t result;
+    char urlBuffer[ 300 ];
     const char * pExpectedUrl = "wss://example.com?X-Amz-ChannelARN=arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123&X-Amz-ClientId=TestClient";
 
     wssEndpoint.pEndpoint = "wss://example.com";
@@ -3915,15 +3942,17 @@ void test_signaling_ConstructConnectWssEndpointRequest_Viewer( void )
     requestBuffer.bodyLength = 0;
 
     result = Signaling_ConstructConnectWssEndpointRequest( &( wssEndpoint ),
-                                                           &( connectWssEndpointRequestInfo ), &( requestBuffer ) );
+                                                           &( connectWssEndpointRequestInfo ),
+                                                           &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_TRUE( strstr( requestBuffer.pUrl, "X-Amz-ClientId=TestClient" ) != NULL );
+    TEST_ASSERT_NOT_NULL( strstr( requestBuffer.pUrl, "X-Amz-ClientId=TestClient" ) );
     TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
                        requestBuffer.urlLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
-                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
+                                  requestBuffer.pUrl,
+                                   requestBuffer.urlLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -3931,13 +3960,13 @@ void test_signaling_ConstructConnectWssEndpointRequest_Viewer( void )
 /**
  * @brief Validate Signaling Construct Connect Web-Sockets Endpoint Request fail functionality for Bad Parameters.
  */
-void test_signaling_ConstructConnectWssEndpointRequest_Url_OutofMemory( void )
+void test_signaling_ConstructConnectWssEndpointRequest_UrlOutofMemory( void )
 {
     SignalingChannelEndpoint_t wssEndpoint = { 0 };
     ConnectWssEndpointRequestInfo_t connectWssEndpointRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
-    char urlBuffer[ 30 ];                     /* The url buffer is small */
     SignalingResult_t result;
+    char urlBuffer[ 30 ]; /* The url buffer is too small to fit the complete URL. */
 
     wssEndpoint.pEndpoint = "wss://example.com";
     wssEndpoint.endpointLength = strlen( wssEndpoint.pEndpoint );
@@ -3954,7 +3983,8 @@ void test_signaling_ConstructConnectWssEndpointRequest_Url_OutofMemory( void )
     requestBuffer.bodyLength = 0;
 
     result = Signaling_ConstructConnectWssEndpointRequest( &( wssEndpoint ),
-                                                           &( connectWssEndpointRequestInfo ), &( requestBuffer ) );
+                                                           &( connectWssEndpointRequestInfo ),
+                                                           &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
                        result );
@@ -3968,12 +3998,13 @@ void test_signaling_ConstructConnectWssEndpointRequest_Url_OutofMemory( void )
 void test_signaling_ConstructWssMessage_BadParams( void )
 {
     WssSendMessage_t wssSendMessage = { 0 };
+    SignalingResult_t result;
     char messageBuffer[ 300 ];
     size_t messageBufferLength = sizeof( messageBuffer );
-    SignalingResult_t result;
 
     result = Signaling_ConstructWssMessage( NULL,
-                                            &( messageBuffer[ 0 ] ), &( messageBufferLength ) );
+                                            &( messageBuffer[ 0 ] ),
+                                            &( messageBufferLength ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -3981,7 +4012,8 @@ void test_signaling_ConstructWssMessage_BadParams( void )
     /*      <------------------------------------------------------------------------------------------>      */
 
     result = Signaling_ConstructWssMessage( &( wssSendMessage ),
-                                            NULL, &( messageBufferLength ) );
+                                            NULL,
+                                            &( messageBufferLength ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -3991,7 +4023,8 @@ void test_signaling_ConstructWssMessage_BadParams( void )
     wssSendMessage.pBase64EncodedMessage = NULL;
 
     result = Signaling_ConstructWssMessage( &( wssSendMessage ),
-                                            &( messageBuffer[ 0 ] ), &( messageBufferLength ) );
+                                            &( messageBuffer[ 0 ] ),
+                                            &( messageBufferLength ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -4003,7 +4036,9 @@ void test_signaling_ConstructWssMessage_BadParams( void )
     wssSendMessage.pRecipientClientId = NULL;
 
     result = Signaling_ConstructWssMessage( &( wssSendMessage ),
-                                            &( messageBuffer[ 0 ] ), &( messageBufferLength ) );
+                                            &( messageBuffer[ 0 ] ),
+                                            &( messageBufferLength ) );
+
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 }
@@ -4016,15 +4051,16 @@ void test_signaling_ConstructWssMessage_BadParams( void )
 void test_signaling_ConstructWssMessage_SdpOffer( void )
 {
     WssSendMessage_t wssSendMessage = { 0 };
+    SignalingResult_t result;
     char messageBuffer[ 300 ];
     size_t messageBufferLength = sizeof( messageBuffer );
-    SignalingResult_t result;
-    const char * pExpectedMessage = "{"
-                                        "\"action\":\"SDP_OFFER\","
-                                        "\"RecipientClientId\":\"TestClientId\","
-                                        "\"MessagePayload\":\"base64encodedmessage\","
-                                        "\"CorrelationId\":\"TestCorrelationId\""
-                                    "}";
+    const char * pExpectedMessage =
+    "{"
+        "\"action\":\"SDP_OFFER\","
+        "\"RecipientClientId\":\"TestClientId\","
+        "\"MessagePayload\":\"base64encodedmessage\","
+        "\"CorrelationId\":\"TestCorrelationId\""
+    "}";
 
     wssSendMessage.messageType = SIGNALING_TYPE_MESSAGE_SDP_OFFER;
     wssSendMessage.pBase64EncodedMessage = "base64encodedmessage";
@@ -4035,13 +4071,16 @@ void test_signaling_ConstructWssMessage_SdpOffer( void )
     wssSendMessage.correlationIdLength = strlen( wssSendMessage.pCorrelationId );
 
     result = Signaling_ConstructWssMessage( &( wssSendMessage ),
-                                            messageBuffer, &( messageBufferLength ) );
+                                            &( messageBuffer[ 0 ] ),
+                                            &( messageBufferLength ) );
+
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedMessage ),
-                       strlen( messageBuffer ) );
-    TEST_ASSERT_EQUAL_STRING( pExpectedMessage,
-                              messageBuffer );
+                       messageBufferLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedMessage,
+                                  &( messageBuffer [ 0 ] ),
+                                  messageBufferLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -4052,15 +4091,16 @@ void test_signaling_ConstructWssMessage_SdpOffer( void )
 void test_signaling_ConstructWssMessage_SdpAnswer( void )
 {
     WssSendMessage_t wssSendMessage = { 0 };
+    SignalingResult_t result;
     char messageBuffer[ 300 ];
     size_t messageBufferLength = sizeof( messageBuffer );
-    SignalingResult_t result;
-    const char * pExpectedMessage = "{"
-                                        "\"action\":\"SDP_ANSWER\","
-                                        "\"RecipientClientId\":\"TestClientId\","
-                                        "\"MessagePayload\":\"base64encodedmessage\","
-                                        "\"CorrelationId\":\"TestCorrelationId\""
-                                    "}";
+    const char * pExpectedMessage =
+    "{"
+        "\"action\":\"SDP_ANSWER\","
+        "\"RecipientClientId\":\"TestClientId\","
+        "\"MessagePayload\":\"base64encodedmessage\","
+        "\"CorrelationId\":\"TestCorrelationId\""
+    "}";
 
     wssSendMessage.messageType = SIGNALING_TYPE_MESSAGE_SDP_ANSWER;
     wssSendMessage.pBase64EncodedMessage = "base64encodedmessage";
@@ -4071,13 +4111,16 @@ void test_signaling_ConstructWssMessage_SdpAnswer( void )
     wssSendMessage.correlationIdLength = strlen( wssSendMessage.pCorrelationId );
 
     result = Signaling_ConstructWssMessage( &( wssSendMessage ),
-                                            messageBuffer, &( messageBufferLength ) );
+                                            &( messageBuffer[ 0 ] ),
+                                            &( messageBufferLength ) );
+
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedMessage ),
-                       strlen( messageBuffer ) );
-    TEST_ASSERT_EQUAL_STRING( pExpectedMessage,
-                              messageBuffer );
+                       messageBufferLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedMessage,
+                                  messageBuffer,
+                                  messageBufferLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -4091,12 +4134,13 @@ void test_signaling_ConstructWssMessage_IceCandidate( void )
     char messageBuffer[ 300 ];
     size_t messageBufferLength = sizeof( messageBuffer );
     SignalingResult_t result;
-    const char * pExpectedMessage = "{"
-                                        "\"action\":\"ICE_CANDIDATE\","
-                                        "\"RecipientClientId\":\"TestClientId\","
-                                        "\"MessagePayload\":\"base64encodedmessage\","
-                                        "\"CorrelationId\":\"TestCorrelationId\""
-                                    "}";
+    const char * pExpectedMessage =
+    "{"
+        "\"action\":\"ICE_CANDIDATE\","
+        "\"RecipientClientId\":\"TestClientId\","
+        "\"MessagePayload\":\"base64encodedmessage\","
+        "\"CorrelationId\":\"TestCorrelationId\""
+    "}";
 
     wssSendMessage.messageType = SIGNALING_TYPE_MESSAGE_ICE_CANDIDATE;
     wssSendMessage.pBase64EncodedMessage = "base64encodedmessage";
@@ -4107,13 +4151,15 @@ void test_signaling_ConstructWssMessage_IceCandidate( void )
     wssSendMessage.correlationIdLength = strlen( wssSendMessage.pCorrelationId );
 
     result = Signaling_ConstructWssMessage( &( wssSendMessage ),
-                                            messageBuffer, &( messageBufferLength ) );
+                                            &( messageBuffer[ 0 ] ),
+                                            &( messageBufferLength ) );
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedMessage ),
-                       strlen( messageBuffer ) );
-    TEST_ASSERT_EQUAL_STRING( pExpectedMessage,
-                              messageBuffer );
+                       messageBufferLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedMessage,
+                                  &( messageBuffer[ 0 ] ),
+                                  messageBufferLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -4121,18 +4167,19 @@ void test_signaling_ConstructWssMessage_IceCandidate( void )
 /**
  * @brief Validate Signaling Construct Web-Socket Message functionality.
  */
-void test_signaling_ConstructWssMessage_Unkown( void )
+void test_signaling_ConstructWssMessage_Unknown( void )
 {
     WssSendMessage_t wssSendMessage = { 0 };
+    SignalingResult_t result;
     char messageBuffer[ 300 ];
     size_t messageBufferLength = sizeof( messageBuffer );
-    SignalingResult_t result;
-    const char * pExpectedMessage = "{"
-                                        "\"action\":\"UNKNOWN\","
-                                        "\"RecipientClientId\":\"TestClientId\","
-                                        "\"MessagePayload\":\"base64encodedmessage\","
-                                        "\"CorrelationId\":\"TestCorrelationId\""
-                                    "}";
+    const char * pExpectedMessage =
+    "{"
+        "\"action\":\"UNKNOWN\","
+        "\"RecipientClientId\":\"TestClientId\","
+        "\"MessagePayload\":\"base64encodedmessage\","
+        "\"CorrelationId\":\"TestCorrelationId\""
+    "}";
 
     wssSendMessage.messageType = SIGNALING_TYPE_MESSAGE_UNKNOWN;
     wssSendMessage.pBase64EncodedMessage = "base64encodedmessage";
@@ -4143,13 +4190,16 @@ void test_signaling_ConstructWssMessage_Unkown( void )
     wssSendMessage.correlationIdLength = strlen( wssSendMessage.pCorrelationId );
 
     result = Signaling_ConstructWssMessage( &( wssSendMessage ),
-                                            messageBuffer, &( messageBufferLength ) );
+                                            &( messageBuffer[ 0 ] ),
+                                            &( messageBufferLength ) );
+
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedMessage ),
-                       strlen( messageBuffer ) );
-    TEST_ASSERT_EQUAL_STRING( pExpectedMessage,
-                              messageBuffer );
+                       messageBufferLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedMessage,
+                                  &( messageBuffer[ 0 ] ),
+                                  messageBufferLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -4160,9 +4210,9 @@ void test_signaling_ConstructWssMessage_Unkown( void )
 void test_signaling_ConstructWssMessage_OutofMemory( void )
 {
     WssSendMessage_t wssSendMessage = { 0 };
-    char messageBuffer[ 100 ];                  /* Correlation ID is not added in the buffer properly */
-    size_t messageBufferLength = sizeof( messageBuffer );
     SignalingResult_t result;
+    char messageBuffer[ 100 ]; /* Buffer not large enough to contains Correlation ID. */
+    size_t messageBufferLength = sizeof( messageBuffer );
 
     wssSendMessage.messageType = SIGNALING_TYPE_MESSAGE_SDP_OFFER;
     wssSendMessage.pBase64EncodedMessage = "base64encodedmessage";
@@ -4173,7 +4223,9 @@ void test_signaling_ConstructWssMessage_OutofMemory( void )
     wssSendMessage.correlationIdLength = strlen( wssSendMessage.pCorrelationId );
 
     result = Signaling_ConstructWssMessage( &( wssSendMessage ),
-                                            messageBuffer, &( messageBufferLength ) );
+                                            messageBuffer,
+                                            &( messageBufferLength ) );
+
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
                        result );
 }
@@ -4183,10 +4235,10 @@ void test_signaling_ConstructWssMessage_OutofMemory( void )
 /**
  * @brief Validate Signaling Construct Web-Socket Message functionality.
  */
-void test_signaling_ConstructWssMessage_OutofMemory_ClosingBracket( void )
+void test_signaling_ConstructWssMessage_OutofMemoryClosingBracket( void )
 {
     WssSendMessage_t wssSendMessage = { 0 };
-    char messageBuffer[ 133 ];                  /* Closing is not added in the buffer properly */
+    char messageBuffer[ 133 ]; /* Buffer not large enough to contains closing bracket. */
     size_t messageBufferLength = sizeof( messageBuffer );
     SignalingResult_t result;
 
@@ -4199,7 +4251,9 @@ void test_signaling_ConstructWssMessage_OutofMemory_ClosingBracket( void )
     wssSendMessage.correlationIdLength = strlen( wssSendMessage.pCorrelationId );
 
     result = Signaling_ConstructWssMessage( &( wssSendMessage ),
-                                            messageBuffer, &( messageBufferLength ) );
+                                            messageBuffer,
+                                            &( messageBufferLength ) );
+
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
                        result );
 }
@@ -4212,14 +4266,15 @@ void test_signaling_ConstructWssMessage_OutofMemory_ClosingBracket( void )
 void test_signaling_ConstructWssMessage_NoCorrelationId( void )
 {
     WssSendMessage_t wssSendMessage = { 0 };
+    SignalingResult_t result;
     char messageBuffer[ 300 ];
     size_t messageBufferLength = sizeof( messageBuffer );
-    SignalingResult_t result;
-    const char * pExpectedMessage = "{"
-                                        "\"action\":\"SDP_OFFER\","
-                                        "\"RecipientClientId\":\"TestClientId\","
-                                        "\"MessagePayload\":\"base64encodedmessage\""
-                                    "}";
+    const char * pExpectedMessage =
+    "{"
+        "\"action\":\"SDP_OFFER\","
+        "\"RecipientClientId\":\"TestClientId\","
+        "\"MessagePayload\":\"base64encodedmessage\""
+    "}";
 
     wssSendMessage.messageType = SIGNALING_TYPE_MESSAGE_SDP_OFFER;
     wssSendMessage.pBase64EncodedMessage = "base64encodedmessage";
@@ -4230,13 +4285,16 @@ void test_signaling_ConstructWssMessage_NoCorrelationId( void )
     wssSendMessage.correlationIdLength = 0;
 
     result = Signaling_ConstructWssMessage( &( wssSendMessage ),
-                                            messageBuffer, &( messageBufferLength ) );
+                                            &( messageBuffer[ 0 ] ),
+                                            &( messageBufferLength ) );
+
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedMessage ),
-                       strlen( messageBuffer ) );
-    TEST_ASSERT_EQUAL_STRING( pExpectedMessage,
-                              messageBuffer );
+                       messageBufferLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedMessage,
+                                  &( messageBuffer[ 0 ] ),
+                                  messageBufferLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -4247,9 +4305,9 @@ void test_signaling_ConstructWssMessage_NoCorrelationId( void )
 void test_signaling_ConstructWssMessage_SmallBuffer( void )
 {
     WssSendMessage_t wssSendMessage = { 0 };
-    char messageBuffer[ 10 ];                           /* A small Message Buffer */
-    size_t messageBufferLength = sizeof( messageBuffer );
     SignalingResult_t result;
+    char messageBuffer[ 10 ]; /* A small Message Buffer. */
+    size_t messageBufferLength = sizeof( messageBuffer );
 
     wssSendMessage.messageType = SIGNALING_TYPE_MESSAGE_SDP_OFFER;
     wssSendMessage.pBase64EncodedMessage = "base64encodedmessage";
@@ -4260,7 +4318,9 @@ void test_signaling_ConstructWssMessage_SmallBuffer( void )
     wssSendMessage.correlationIdLength = strlen( wssSendMessage.pCorrelationId );
 
     result = Signaling_ConstructWssMessage( &( wssSendMessage ),
-                                            messageBuffer, &( messageBufferLength ) );
+                                            messageBuffer,
+                                            &( messageBufferLength ) );
+
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
                        result );
 }
@@ -4277,7 +4337,8 @@ void test_signaling_ParseWssRecvMessage_BadParams( void )
     SignalingResult_t result;
 
     result = Signaling_ParseWssRecvMessage( NULL,
-                                            messageLength, &( wssRecvMessage ) );
+                                            messageLength,
+                                            &( wssRecvMessage ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -4285,7 +4346,8 @@ void test_signaling_ParseWssRecvMessage_BadParams( void )
     /*      <------------------------------------------------------------------------------------------>      */
 
     result = Signaling_ParseWssRecvMessage( message,
-                                            messageLength, NULL );
+                                            messageLength,
+                                            NULL );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -4296,11 +4358,12 @@ void test_signaling_ParseWssRecvMessage_BadParams( void )
 /**
  * @brief Validate Signaling Parse Web-Socket Receive Message functionality.
  */
-void test_signaling_ParseWssRecvMessage_Sdp_Offer( void )
+void test_signaling_ParseWssRecvMessage_SdpOffer( void )
 {
     SignalingResult_t result;
     WssRecvMessage_t wssRecvMessage = { 0 };
-    const char * message = "{"
+    const char * message =
+    "{"
         "\"senderClientId\":\"sender123\","
         "\"messageType\":\"SDP_OFFER\","
         "\"messagePayload\":\"base64encodedpayload\""
@@ -4308,13 +4371,23 @@ void test_signaling_ParseWssRecvMessage_Sdp_Offer( void )
     size_t messageLength = strlen( message );
 
     result = Signaling_ParseWssRecvMessage( message,
-                                            messageLength, &( wssRecvMessage ) );
+                                            messageLength,
+                                            &( wssRecvMessage ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL_STRING_LEN( "sender123", wssRecvMessage.pSenderClientId, wssRecvMessage.senderClientIdLength );
-    TEST_ASSERT_EQUAL( SIGNALING_TYPE_MESSAGE_SDP_OFFER, wssRecvMessage.messageType );
-    TEST_ASSERT_EQUAL_STRING_LEN( "base64encodedpayload", wssRecvMessage.pBase64EncodedPayload, wssRecvMessage.base64EncodedPayloadLength );
+    TEST_ASSERT_EQUAL( strlen( "sender123" ),
+                       wssRecvMessage.senderClientIdLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "sender123",
+                                   wssRecvMessage.pSenderClientId,
+                                   wssRecvMessage.senderClientIdLength );
+    TEST_ASSERT_EQUAL( SIGNALING_TYPE_MESSAGE_SDP_OFFER,
+                       wssRecvMessage.messageType );
+    TEST_ASSERT_EQUAL( strlen( "base64encodedpayload" ),
+                       wssRecvMessage.base64EncodedPayloadLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "base64encodedpayload",
+                                  wssRecvMessage.pBase64EncodedPayload,
+                                  wssRecvMessage.base64EncodedPayloadLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -4322,11 +4395,12 @@ void test_signaling_ParseWssRecvMessage_Sdp_Offer( void )
 /**
  * @brief Validate Signaling Parse Web-Socket Receive Message functionality.
  */
-void test_signaling_ParseWssRecvMessage_Sdp_Answer( void )
+void test_signaling_ParseWssRecvMessage_SdpAnswer( void )
 {
     SignalingResult_t result;
     WssRecvMessage_t wssRecvMessage = { 0 };
-    const char *message = "{"
+    const char *message =
+    "{"
         "\"senderClientId\":\"sender123\","
         "\"messageType\":\"SDP_ANSWER\","
         "\"messagePayload\":\"base64encodedpayload\""
@@ -4334,13 +4408,23 @@ void test_signaling_ParseWssRecvMessage_Sdp_Answer( void )
     size_t messageLength = strlen( message );
 
     result = Signaling_ParseWssRecvMessage( message,
-                                            messageLength, &( wssRecvMessage ) );
+                                            messageLength,
+                                            &( wssRecvMessage ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL_STRING_LEN( "sender123", wssRecvMessage.pSenderClientId, wssRecvMessage.senderClientIdLength );
-    TEST_ASSERT_EQUAL( SIGNALING_TYPE_MESSAGE_SDP_ANSWER, wssRecvMessage.messageType );
-    TEST_ASSERT_EQUAL_STRING_LEN( "base64encodedpayload", wssRecvMessage.pBase64EncodedPayload, wssRecvMessage.base64EncodedPayloadLength );
+    TEST_ASSERT_EQUAL( strlen( "sender123" ),
+                       wssRecvMessage.senderClientIdLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "sender123",
+                                  wssRecvMessage.pSenderClientId,
+                                  wssRecvMessage.senderClientIdLength );
+    TEST_ASSERT_EQUAL( SIGNALING_TYPE_MESSAGE_SDP_ANSWER,
+                       wssRecvMessage.messageType );
+    TEST_ASSERT_EQUAL( strlen( "base64encodedpayload" ),
+                       wssRecvMessage.base64EncodedPayloadLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "base64encodedpayload",
+                                  wssRecvMessage.pBase64EncodedPayload,
+                                  wssRecvMessage.base64EncodedPayloadLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -4352,7 +4436,8 @@ void test_signaling_ParseWssRecvMessage_IceCandidate( void )
 {
     SignalingResult_t result;
     WssRecvMessage_t wssRecvMessage = { 0 };
-    const char *message = "{"
+    const char *message =
+    "{"
         "\"senderClientId\":\"sender123\","
         "\"messageType\":\"ICE_CANDIDATE\","
         "\"messagePayload\":\"base64encodedpayload\""
@@ -4360,13 +4445,23 @@ void test_signaling_ParseWssRecvMessage_IceCandidate( void )
     size_t messageLength = strlen( message );
 
     result = Signaling_ParseWssRecvMessage( message,
-                                            messageLength, &( wssRecvMessage ) );
+                                            messageLength,
+                                            &( wssRecvMessage ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL_STRING_LEN( "sender123", wssRecvMessage.pSenderClientId, wssRecvMessage.senderClientIdLength );
-    TEST_ASSERT_EQUAL( SIGNALING_TYPE_MESSAGE_ICE_CANDIDATE, wssRecvMessage.messageType );
-    TEST_ASSERT_EQUAL_STRING_LEN( "base64encodedpayload", wssRecvMessage.pBase64EncodedPayload, wssRecvMessage.base64EncodedPayloadLength );
+    TEST_ASSERT_EQUAL( strlen( "sender123" ),
+                       wssRecvMessage.senderClientIdLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "sender123",
+                                  wssRecvMessage.pSenderClientId,
+                                  wssRecvMessage.senderClientIdLength );
+    TEST_ASSERT_EQUAL( SIGNALING_TYPE_MESSAGE_ICE_CANDIDATE,
+                       wssRecvMessage.messageType );
+    TEST_ASSERT_EQUAL( strlen( "base64encodedpayload" ),
+                       wssRecvMessage.base64EncodedPayloadLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "base64encodedpayload",
+                                  wssRecvMessage.pBase64EncodedPayload,
+                                  wssRecvMessage.base64EncodedPayloadLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -4378,7 +4473,8 @@ void test_signaling_ParseWssRecvMessage_GoAway( void )
 {
     SignalingResult_t result;
     WssRecvMessage_t wssRecvMessage = { 0 };
-    const char *message = "{"
+    const char *message =
+    "{"
         "\"senderClientId\":\"sender123\","
         "\"messageType\":\"GO_AWAY\","
         "\"messagePayload\":\"base64encodedpayload\""
@@ -4386,13 +4482,23 @@ void test_signaling_ParseWssRecvMessage_GoAway( void )
     size_t messageLength = strlen( message );
 
     result = Signaling_ParseWssRecvMessage( message,
-                                            messageLength, &( wssRecvMessage ) );
+                                            messageLength,
+                                            &( wssRecvMessage ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL_STRING_LEN( "sender123", wssRecvMessage.pSenderClientId, wssRecvMessage.senderClientIdLength );
-    TEST_ASSERT_EQUAL( SIGNALING_TYPE_MESSAGE_GO_AWAY, wssRecvMessage.messageType );
-    TEST_ASSERT_EQUAL_STRING_LEN( "base64encodedpayload", wssRecvMessage.pBase64EncodedPayload, wssRecvMessage.base64EncodedPayloadLength );
+    TEST_ASSERT_EQUAL( strlen( "sender123" ),
+                       wssRecvMessage.senderClientIdLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "sender123",
+                                  wssRecvMessage.pSenderClientId,
+                                  wssRecvMessage.senderClientIdLength );
+    TEST_ASSERT_EQUAL( SIGNALING_TYPE_MESSAGE_GO_AWAY,
+                       wssRecvMessage.messageType );
+    TEST_ASSERT_EQUAL( strlen( "base64encodedpayload" ),
+                       wssRecvMessage.base64EncodedPayloadLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "base64encodedpayload",
+                                  wssRecvMessage.pBase64EncodedPayload,
+                                  wssRecvMessage.base64EncodedPayloadLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -4404,21 +4510,32 @@ void test_signaling_ParseWssRecvMessage_ExcludeNullTerminator( void )
 {
     SignalingResult_t result;
     WssRecvMessage_t wssRecvMessage = { 0 };
-    const char *message = "{"
+    const char *message =
+    "{"
         "\"senderClientId\":\"sender123\","
         "\"messageType\":\"RECONNECT_ICE_SERVER\","
         "\"messagePayload\":\"base64encodedpayload\""
-    "}\0";          // Explicitly include null terminator
-    size_t messageLength = strlen(message) + 1 ;                 // Length including null terminator
+    "}";
+    size_t messageLength = strlen( message ) + 1 ; /* Length including null terminator. */
 
     result = Signaling_ParseWssRecvMessage( message,
-                                            messageLength, &( wssRecvMessage ) );
+                                            messageLength,
+                                            &( wssRecvMessage ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL_STRING_LEN( "sender123", wssRecvMessage.pSenderClientId, wssRecvMessage.senderClientIdLength );
-    TEST_ASSERT_EQUAL( SIGNALING_TYPE_MESSAGE_RECONNECT_ICE_SERVER, wssRecvMessage.messageType );
-    TEST_ASSERT_EQUAL_STRING_LEN( "base64encodedpayload", wssRecvMessage.pBase64EncodedPayload, wssRecvMessage.base64EncodedPayloadLength );
+    TEST_ASSERT_EQUAL( strlen( "sender123" ),
+                       wssRecvMessage.senderClientIdLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "sender123",
+                                  wssRecvMessage.pSenderClientId,
+                                  wssRecvMessage.senderClientIdLength );
+    TEST_ASSERT_EQUAL( SIGNALING_TYPE_MESSAGE_RECONNECT_ICE_SERVER,
+                       wssRecvMessage.messageType );
+    TEST_ASSERT_EQUAL( strlen( "base64encodedpayload" ),
+                       wssRecvMessage.base64EncodedPayloadLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "base64encodedpayload",
+                                  wssRecvMessage.pBase64EncodedPayload,
+                                  wssRecvMessage.base64EncodedPayloadLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -4430,7 +4547,8 @@ void test_signaling_ParseWssRecvMessage_ReconnectIceServer( void )
 {
     SignalingResult_t result;
     WssRecvMessage_t wssRecvMessage = { 0 };
-    const char *message = "{"
+    const char *message =
+    "{"
         "\"senderClientId\":\"sender123\","
         "\"messageType\":\"RECONNECT_ICE_SERVER\","
         "\"messagePayload\":\"base64encodedpayload\""
@@ -4442,9 +4560,18 @@ void test_signaling_ParseWssRecvMessage_ReconnectIceServer( void )
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL_STRING_LEN( "sender123", wssRecvMessage.pSenderClientId, wssRecvMessage.senderClientIdLength );
-    TEST_ASSERT_EQUAL( SIGNALING_TYPE_MESSAGE_RECONNECT_ICE_SERVER, wssRecvMessage.messageType );
-    TEST_ASSERT_EQUAL_STRING_LEN( "base64encodedpayload", wssRecvMessage.pBase64EncodedPayload, wssRecvMessage.base64EncodedPayloadLength );
+    TEST_ASSERT_EQUAL( strlen( "sender123" ),
+                       wssRecvMessage.senderClientIdLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "sender123",
+                                  wssRecvMessage.pSenderClientId,
+                                  wssRecvMessage.senderClientIdLength );
+    TEST_ASSERT_EQUAL( SIGNALING_TYPE_MESSAGE_RECONNECT_ICE_SERVER,
+                       wssRecvMessage.messageType );
+    TEST_ASSERT_EQUAL( strlen( "base64encodedpayload" ),
+                       wssRecvMessage.base64EncodedPayloadLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "base64encodedpayload",
+                                  wssRecvMessage.pBase64EncodedPayload,
+                                  wssRecvMessage.base64EncodedPayloadLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -4456,28 +4583,48 @@ void test_signaling_ParseWssRecvMessage_StatusResponse( void )
 {
     SignalingResult_t result;
     WssRecvMessage_t wssRecvMessage = { 0 };
-    const char *message = "{"
+    const char *message =
+    "{"
         "\"messageType\":\"STATUS_RESPONSE\","
-        "\"statusResponse\":{"
+        "\"statusResponse\":"
+        "{"
             "\"correlationId\":\"corr123\","
             "\"errorType\":\"None\","
             "\"statusCode\":\"200\","
             "\"description\":\"OK\","
-            "\"Unkown\":\"value\""                   /* Unkown Tags are ignored. */
+            "\"Unknown\":\"value\"" /* Unknown Tags are ignored. */
         "}"
     "}";
     size_t messageLength = strlen( message );
 
     result = Signaling_ParseWssRecvMessage( message,
-                                            messageLength, &( wssRecvMessage ) );
+                                            messageLength,
+                                            &( wssRecvMessage ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL( SIGNALING_TYPE_MESSAGE_STATUS_RESPONSE, wssRecvMessage.messageType );
-    TEST_ASSERT_EQUAL_STRING_LEN( "corr123", wssRecvMessage.statusResponse.pCorrelationId, wssRecvMessage.statusResponse.correlationIdLength );
-    TEST_ASSERT_EQUAL_STRING_LEN( "None", wssRecvMessage.statusResponse.pErrorType, wssRecvMessage.statusResponse.errorTypeLength );
-    TEST_ASSERT_EQUAL_STRING_LEN( "200", wssRecvMessage.statusResponse.pStatusCode, wssRecvMessage.statusResponse.statusCodeLength );
-    TEST_ASSERT_EQUAL_STRING_LEN( "OK", wssRecvMessage.statusResponse.pDescription, wssRecvMessage.statusResponse.descriptionLength );
+    TEST_ASSERT_EQUAL( SIGNALING_TYPE_MESSAGE_STATUS_RESPONSE,
+                       wssRecvMessage.messageType );
+    TEST_ASSERT_EQUAL( strlen( "corr123" ),
+                       wssRecvMessage.statusResponse.correlationIdLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "corr123",
+                                  wssRecvMessage.statusResponse.pCorrelationId,
+                                  wssRecvMessage.statusResponse.correlationIdLength );
+    TEST_ASSERT_EQUAL( strlen( "None" ),
+                       wssRecvMessage.statusResponse.errorTypeLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "None",
+                                  wssRecvMessage.statusResponse.pErrorType,
+                                  wssRecvMessage.statusResponse.errorTypeLength );
+    TEST_ASSERT_EQUAL( strlen( "200" ),
+                       wssRecvMessage.statusResponse.statusCodeLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "200",
+                                  wssRecvMessage.statusResponse.pStatusCode,
+                                  wssRecvMessage.statusResponse.statusCodeLength );
+    TEST_ASSERT_EQUAL( strlen( "OK" ),
+                       wssRecvMessage.statusResponse.descriptionLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "OK",
+                                  wssRecvMessage.statusResponse.pDescription,
+                                  wssRecvMessage.statusResponse.descriptionLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -4489,11 +4636,14 @@ void test_signaling_ParseWssRecvMessage_InvalidJson( void )
 {
     SignalingResult_t result;
     WssRecvMessage_t wssRecvMessage = { 0 };
-    const char * message = "{\"senderClientId\":\"sender123\",";  /* Missing closing brace */
+    const char * message =
+    "{"
+        "\"senderClientId\":\"sender123\",";  /* Missing closing brace. */
     size_t messageLength = strlen( message );
 
     result = Signaling_ParseWssRecvMessage( message,
-                                            messageLength, &( wssRecvMessage ) );
+                                            messageLength,
+                                            &( wssRecvMessage ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
                        result );
@@ -4504,24 +4654,27 @@ void test_signaling_ParseWssRecvMessage_InvalidJson( void )
 /**
  * @brief Validate Signaling Parse Web-Socket Receive Message functionality.
  */
-void test_signaling_ParseWssRecvMessage_UnkownMessageType( void )
+void test_signaling_ParseWssRecvMessage_UnknownMessageType( void )
 {
     SignalingResult_t result;
     WssRecvMessage_t wssRecvMessage = { 0 };
-    const char *message  = "{"
+    const char *message  =
+    "{"
         "\"senderClientId\":\"sender123\","
-        "\"messageType\":\"UNKNOWN_TYPE\","                 /* Unkown Message Type */
+        "\"messageType\":\"UNKNOWN_TYPE\"," /* Unknown Message Type. */
         "\"messagePayload\":\"base64encodedpayload\","
-        "\"Unkown\":\"unkown-value\""                       /* This Unkown Tag is ignored */
+        "\"Unknown\":\"unknown-value\"" /* This Unknown Tag is ignored. */
     "}";
     size_t messageLength = strlen( message );
 
     result = Signaling_ParseWssRecvMessage( message,
-                                            messageLength, &( wssRecvMessage ) );
+                                            messageLength,
+                                            &( wssRecvMessage ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL( SIGNALING_TYPE_MESSAGE_UNKNOWN, wssRecvMessage.messageType );
+    TEST_ASSERT_EQUAL( SIGNALING_TYPE_MESSAGE_UNKNOWN,
+                       wssRecvMessage.messageType );
 }
 
 /*-----------------------------------------------------------*/
@@ -4533,14 +4686,16 @@ void test_signaling_ParseWssRecvMessage_UnexpectedStatusResponse( void )
 {
     SignalingResult_t result;
     WssRecvMessage_t wssRecvMessage = { 0 };
-    const char *message  = "{"
+    const char *message  =
+    "{"
         "\"messageType\":\"STATUS_RESPONSE\","
-        "\"statusResponse\":\"invalid\""            /* Invalid Status Response */
+        "\"statusResponse\":\"invalid\"" /* Invalid Status Response. */
     "}";
     size_t messageLength = strlen( message );
 
     result = Signaling_ParseWssRecvMessage( message,
-                                            messageLength, &( wssRecvMessage ) );
+                                            messageLength,
+                                            &( wssRecvMessage ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
@@ -4555,15 +4710,19 @@ void test_signaling_ParseWssRecvMessage_InvalidStatusResponse( void )
 {
     SignalingResult_t result;
     WssRecvMessage_t wssRecvMessage = { 0 };
-    const char *message  = "{"
+    const char *message  =
+    "{"
         "\"messageType\":\"STATUS_RESPONSE\","
-        "\"statusResponse\":{"                                      /* Empty Status Response */
+        "\"statusResponse\":"
+        "{"
+            /* Empty Status Response. */
         "}"
     "}";
     size_t messageLength = strlen( message );
 
     result = Signaling_ParseWssRecvMessage( message,
-                                            messageLength, &( wssRecvMessage ) );
+                                            messageLength,
+                                            &( wssRecvMessage ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_STATUS_RESPONSE,
                        result );
@@ -4582,7 +4741,8 @@ void test_signaling_ParseWssRecvMessage_Empty( void )
     size_t messageLength = 0;
 
     result = Signaling_ParseWssRecvMessage( message,
-                                            messageLength, &( wssRecvMessage ) );
+                                            messageLength,
+                                            &( wssRecvMessage ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
                        result );

--- a/test/unit-test/signaling_api/signaling_api_utest.c
+++ b/test/unit-test/signaling_api/signaling_api_utest.c
@@ -1250,9 +1250,9 @@ void test_signaling_ConstructCreateSignalingChannelRequest_UrlOutofMemory( void 
     createSignalingChannelRequestInfo.numTags = 0;
     createSignalingChannelRequestInfo.pTags = NULL;
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
@@ -1287,9 +1287,9 @@ void test_signaling_ConstructCreateSignalingChannelRequest_BodyOutofMemory( void
     createSignalingChannelRequestInfo.numTags = 0;
     createSignalingChannelRequestInfo.pTags = NULL;
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
@@ -1324,9 +1324,9 @@ void test_signaling_ConstructCreateSignalingChannelRequest_BodyClosingBraceOutof
     createSignalingChannelRequestInfo.numTags = 0;
     createSignalingChannelRequestInfo.pTags = NULL;
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
@@ -1595,9 +1595,9 @@ void test_signaling_ConstructCreateSignalingChannelRequest_WithTagsLeftArrayBrac
     createSignalingChannelRequestInfo.numTags = 1;
     createSignalingChannelRequestInfo.pTags = tags;
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
@@ -1643,9 +1643,9 @@ void test_signaling_ConstructCreateSignalingChannelRequest_WithTagsOutofMemory( 
     createSignalingChannelRequestInfo.numTags = 2;
     createSignalingChannelRequestInfo.pTags = tags;
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
@@ -1691,9 +1691,9 @@ void test_signaling_ConstructCreateSignalingChannelRequest_WithTagsRightArrayBra
     createSignalingChannelRequestInfo.numTags = 2;
     createSignalingChannelRequestInfo.pTags = tags;
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
@@ -2013,9 +2013,9 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_UrlOutofMemory( 
     getSignalingChannelEndPointRequestInfo.role = SIGNALING_ROLE_VIEWER;
     getSignalingChannelEndPointRequestInfo.protocols = SIGNALING_PROTOCOL_WEBRTC | SIGNALING_PROTOCOL_WEBSOCKET_SECURE;
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
@@ -2048,9 +2048,9 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_BodyOutofMemory(
     getSignalingChannelEndPointRequestInfo.role = SIGNALING_ROLE_MASTER;
     getSignalingChannelEndPointRequestInfo.protocols = SIGNALING_PROTOCOL_HTTPS | SIGNALING_PROTOCOL_WEBSOCKET_SECURE;
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
@@ -2148,9 +2148,9 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_ChinaRegion( voi
     getSignalingChannelEndPointRequestInfo.role = SIGNALING_ROLE_VIEWER;
     getSignalingChannelEndPointRequestInfo.protocols = SIGNALING_PROTOCOL_HTTPS | SIGNALING_PROTOCOL_WEBSOCKET_SECURE;
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
@@ -2203,9 +2203,9 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_SmallLengthRegio
     getSignalingChannelEndPointRequestInfo.role = SIGNALING_ROLE_MASTER;
     getSignalingChannelEndPointRequestInfo.protocols = SIGNALING_PROTOCOL_WEBSOCKET_SECURE | SIGNALING_PROTOCOL_HTTPS;
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
@@ -2258,9 +2258,9 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_WebSocketsOrWebR
     getSignalingChannelEndPointRequestInfo.role = SIGNALING_ROLE_MASTER;
     getSignalingChannelEndPointRequestInfo.protocols = SIGNALING_PROTOCOL_WEBRTC | SIGNALING_PROTOCOL_WEBSOCKET_SECURE;
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
@@ -2313,9 +2313,9 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_WebRtc( void )
     getSignalingChannelEndPointRequestInfo.role = SIGNALING_ROLE_MASTER;
     getSignalingChannelEndPointRequestInfo.protocols = SIGNALING_PROTOCOL_WEBRTC;
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
@@ -2343,19 +2343,21 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_WebRtc( void )
  */
 void test_signaling_ParseGetSignalingChannelEndpointResponse_BadParams( void )
 {
-    const char * message = "Valid-Message";
-    size_t messageLength = strlen( message );
     SignalingChannelEndpoints_t endpoints;
     SignalingResult_t result;
+    const char * message = "Valid-Message";
+    size_t messageLength = strlen( message );
 
     result = Signaling_ParseGetSignalingChannelEndpointResponse( NULL,
-                                                                 messageLength, &( endpoints ) );
+                                                                 messageLength,
+                                                                 &( endpoints ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     result = Signaling_ParseGetSignalingChannelEndpointResponse( message,
-                                                                 messageLength, NULL );
+                                                                 messageLength,
+                                                                 NULL );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -2368,25 +2370,26 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse_BadParams( void )
  */
 void test_signaling_ParseGetSignalingChannelEndpointResponse_InvalidJson( void )
 {
-    const char * message = "{\"ResourceEndpointList\": [";  /* Missing closing bracket */
-    size_t messageLength = strlen( message );
     SignalingChannelEndpoints_t endpoints;
     SignalingResult_t result;
+    const char * message = "{\"ResourceEndpointList\": [";  /* Missing closing bracket. */
+    size_t messageLength = strlen( message );
 
     result = Signaling_ParseGetSignalingChannelEndpointResponse( message,
-                                                                 messageLength, &( endpoints ) );
+                                                                 messageLength,
+                                                                 &( endpoints ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
                        result );
 
     /* <--------------------------------------------------------------------> */
 
-    const char * message2 = "{"                                  /* Empty JSON */
-                            "}";
+    const char * message2 = "{}"; /* Empty JSON. */
     size_t messageLength2 = strlen( message2 );
 
     result = Signaling_ParseGetSignalingChannelEndpointResponse( message2,
-                                                                 messageLength2, &( endpoints ) );
+                                                                 messageLength2,
+                                                                 &( endpoints ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
                        result );
@@ -2402,12 +2405,14 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse_UnexpectedResponse(
 {
     SignalingChannelEndpoints_t endpoints;
     SignalingResult_t result;
-    const char * message = "{"
-        "\"ResourceEndpointList\": {"                                                   /* Opening Bracket Not JSON Array Type */
+    const char * message =
+    "{"
+        "\"ResourceEndpointList\":"
+        "{" /* Not JSON Array Type. */
             "{\"Protocol\": \"WSS\", \"ResourceEndpoint\": \"wss://example.com\"},"
             "{\"Protocol\": \"HTTPS\", \"ResourceEndpoint\": \"https://example.com\"},"
             "{\"Protocol\": \"WEBRTC\", \"ResourceEndpoint\": \"webrtc://example.com\"}"
-        "}"                                                                              /* Closing Bracket not Not JSON Array Type */
+        "}"
     "}";
     size_t messageLength = strlen( message );
 
@@ -2419,8 +2424,10 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse_UnexpectedResponse(
 
     /*<----------------------------------------------------------------->*/
 
-    const char * message2 = "{"
-        "\"Unkown\": ["                                                                      /* Unkown Key */
+    const char * message2 =
+    "{"
+        "\"Unkown\":" /* Unkown key. */
+        "["
             "{\"Protocol\": \"WSS\", \"ResourceEndpoint\": \"wss://example.com\"},"
             "{\"Protocol\": \"HTTPS\", \"ResourceEndpoint\": \"https://example.com\"},"
             "{\"Protocol\": \"WEBRTC\", \"ResourceEndpoint\": \"webrtc://example.com\"}"
@@ -2429,18 +2436,20 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse_UnexpectedResponse(
     size_t messageLength2 = strlen( message2 );
 
     result = Signaling_ParseGetSignalingChannelEndpointResponse( message2,
-                                                                 messageLength2, &( endpoints ) );
+                                                                 messageLength2,
+                                                                 &( endpoints ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
 
     /*<----------------------------------------------------------------->*/
 
-    const char * message3 = "{\"ResourceEndpointBist\": []}";                                 /* The Key is not known */
+    const char * message3 = "{\"ResourceEndpointBist\": []}"; /* Unknown key. */
     size_t messageLength3 = strlen( message3 );
 
     result = Signaling_ParseGetSignalingChannelEndpointResponse( message3,
-                                                                 messageLength3, &( endpoints ) );
+                                                                 messageLength3,
+                                                                 &( endpoints ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
@@ -2449,66 +2458,90 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse_UnexpectedResponse(
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate Signaling Parse Get Endpoint Response functionality for Unexpected Response.
+ * @brief Validate Signaling Parse Get Endpoint Response functionality for Invalid Protocol.
  */
 void test_signaling_ParseGetSignalingChannelEndpointResponse_InvalidProtocol( void )
 {
     SignalingChannelEndpoints_t endpoints;
     SignalingResult_t result;
-    const char * message = "{"
-        "\"ResourceEndpointList\": ["
-            "{\"Protocol\": \"INVALID\", \"ResourceEndpoint\": \"invalid://example.com\"}"
+    const char * message =
+    "{"
+        "\"ResourceEndpointList\":"
+        "["
+            "{"
+                "\"Protocol\": \"INVALID\","
+                "\"ResourceEndpoint\": \"invalid://example.com\""
+            "}"
         "]"
     "}";
     size_t messageLength = strlen( message );
 
     result = Signaling_ParseGetSignalingChannelEndpointResponse( message,
-                                                                 messageLength, &( endpoints ) );
+                                                                 messageLength,
+                                                                 &( endpoints ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_PROTOCOL,
                        result );
 
     /*<----------------------------------------------------------------->*/
 
-    const char * message2 = "{"
-        "\"ResourceEndpointList\": ["
-            "{\"Protocol\": \"ABS\", \"ResourceEndpoint\": \"abs://example.com\"}"          /* Protocol length == 3  but protocol != WSS */
+    const char * message2 =
+    "{"
+        "\"ResourceEndpointList\":"
+        "["
+            "{"
+                "\"Protocol\": \"ABS\"," /* Protocol length == 3  but protocol != WSS. */
+                "\"ResourceEndpoint\": \"abs://example.com\""
+            "}"
         "]"
     "}";
     size_t messageLength2 = strlen( message2 );
 
     result = Signaling_ParseGetSignalingChannelEndpointResponse( message2,
-                                                                 messageLength2, &( endpoints ) );
+                                                                 messageLength2,
+                                                                 &( endpoints ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_PROTOCOL,
                        result );
 
     /*<----------------------------------------------------------------->*/
 
-    const char * message3 = "{"
-        "\"ResourceEndpointList\": ["
-            "{\"Protocol\": \"HTTPA\", \"ResourceEndpoint\": \"httpa://example.com\"}"          /* Protocol length == 5  but protocol != HTTPS */
+    const char * message3 =
+    "{"
+        "\"ResourceEndpointList\":"
+        "["
+            "{"
+                "\"Protocol\": \"HTTPA\"," /* Protocol length == 5  but protocol != HTTPS. */
+                "\"ResourceEndpoint\": \"httpa://example.com\""
+            "}"
         "]"
     "}";
     size_t messageLength3 = strlen( message3 );
 
     result = Signaling_ParseGetSignalingChannelEndpointResponse( message3,
-                                                                 messageLength3, &( endpoints ) );
+                                                                 messageLength3,
+                                                                 &( endpoints ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_PROTOCOL,
                        result );
 
     /*<----------------------------------------------------------------->*/
 
-    const char * message4 = "{"
-        "\"ResourceEndpointList\": ["
-            "{\"Protocol\": \"WEBRTA\", \"ResourceEndpoint\": \"webrta://example.com\"}"          /* Protocol length == 6  but protocol != WEBRTC */
+    const char * message4 =
+    "{"
+        "\"ResourceEndpointList\":"
+        "["
+            "{"
+                "\"Protocol\": \"WEBRTA\"," /* Protocol length == 6  but protocol != WEBRTC. */
+                "\"ResourceEndpoint\": \"webrta://example.com\""
+            "}"
         "]"
     "}";
     size_t messageLength4 = strlen( message4 );
 
     result = Signaling_ParseGetSignalingChannelEndpointResponse( message4,
-                                                                 messageLength4, &( endpoints ) );
+                                                                 messageLength4,
+                                                                 &( endpoints ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_PROTOCOL,
                        result );
@@ -2523,34 +2556,43 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse( void )
 {
     SignalingChannelEndpoints_t endpoints;
     SignalingResult_t result;
-    const char *message = "{"
-        "\"ResourceEndpointList\": ["
+    const char *message =
+    "{"
+        "\"ResourceEndpointList\":"
+        "["
             "{\"Protocol\": \"WSS\", \"ResourceEndpoint\": \"wss://example.com\"},"
             "{\"Protocol\": \"HTTPS\", \"ResourceEndpoint\": \"https://example.com\"},"
             "{\"Protocol\": \"WEBRTC\", \"ResourceEndpoint\": \"webrtc://example.com\"},"
-            "{\"Unkown\": \"WEBRTC\", \"ResourceEndpoint\": \"webrtc://example.com\"},"      /* Unkown Tag is ignored */
-            "{\"Protocol\": \"WEBRTC\", \"Unkown\": \"webrtc://example.com\"}"               /* Unkown Tag is ignored */
+            "{\"Unkown\": \"WEBRTC\", \"ResourceEndpoint\": \"webrtc://example.com\"},"      /* Unkown Tag is ignored. */
+            "{\"Protocol\": \"WEBRTC\", \"Unkown\": \"webrtc://example.com\"}"               /* Unkown Tag is ignored. */
         "]"
     "}";
     size_t messageLength = strlen( message );
-    const char * wssURL = "wss://example.com";
-    const char * httpsURL = "https://example.com";
-    const char * webrtcURL = "webrtc://example.com";
+    const char * expectedWssURL = "wss://example.com";
+    const char * expectedHttpsURL = "https://example.com";
+    const char * expectedWebrtcURL = "webrtc://example.com";
 
     result = Signaling_ParseGetSignalingChannelEndpointResponse( message,
-                                                                 messageLength, &( endpoints ) );
+                                                                 messageLength,
+                                                                 &( endpoints ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL( strlen( wssURL ),
+    TEST_ASSERT_EQUAL( strlen( expectedWssURL ),
                        endpoints.wssEndpoint.endpointLength );
-    TEST_ASSERT_EQUAL_STRING_LEN( wssURL, endpoints.wssEndpoint.pEndpoint, strlen( wssURL ) );
-    TEST_ASSERT_EQUAL( strlen( httpsURL ),
+    TEST_ASSERT_EQUAL_STRING_LEN( expectedWssURL,
+                                  endpoints.wssEndpoint.pEndpoint,
+                                   endpoints.wssEndpoint.endpointLength );
+    TEST_ASSERT_EQUAL( strlen( expectedHttpsURL ),
                        endpoints.httpsEndpoint.endpointLength );
-    TEST_ASSERT_EQUAL_STRING_LEN( httpsURL, endpoints.httpsEndpoint.pEndpoint, strlen( httpsURL ) );
-    TEST_ASSERT_EQUAL( strlen( webrtcURL ),
+    TEST_ASSERT_EQUAL_STRING_LEN( expectedHttpsURL,
+                                  endpoints.httpsEndpoint.pEndpoint,
+                                  endpoints.httpsEndpoint.endpointLength );
+    TEST_ASSERT_EQUAL( strlen( expectedWebrtcURL ),
                        endpoints.webrtcEndpoint.endpointLength );
-    TEST_ASSERT_EQUAL_STRING_LEN( webrtcURL, endpoints.webrtcEndpoint.pEndpoint, strlen( webrtcURL ) );
+    TEST_ASSERT_EQUAL_STRING_LEN( expectedWebrtcURL,
+                                  endpoints.webrtcEndpoint.pEndpoint,
+                                  endpoints.webrtcEndpoint.endpointLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -2562,33 +2604,41 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse_SmallCaps( void )
 {
     SignalingChannelEndpoints_t endpoints;
     SignalingResult_t result;
-    const char *message = "{"
-        "\"ResourceEndpointList\": ["
+    const char *message =
+    "{"
+        "\"ResourceEndpointList\":"
+        "["
             "{\"Protocol\": \"wss\", \"ResourceEndpoint\": \"wss://example.com\"},"
             "{\"Protocol\": \"https\", \"ResourceEndpoint\": \"https://example.com\"},"
             "{\"Protocol\": \"webrtc\", \"ResourceEndpoint\": \"webrtc://example.com\"}"
         "]"
     "}";
-
     size_t messageLength = strlen( message );
-    const char * wssURL = "wss://example.com";
-    const char * httpsURL = "https://example.com";
-    const char * webrtcURL = "webrtc://example.com";
+    const char * expectedWssURL = "wss://example.com";
+    const char * expectedHttpsURL = "https://example.com";
+    const char * expectedWebrtcURL = "webrtc://example.com";
 
     result = Signaling_ParseGetSignalingChannelEndpointResponse( message,
-                                                                 messageLength, &( endpoints ) );
+                                                                 messageLength,
+                                                                 &( endpoints ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL( strlen( wssURL ),
+    TEST_ASSERT_EQUAL( strlen( expectedWssURL ),
                        endpoints.wssEndpoint.endpointLength );
-    TEST_ASSERT_EQUAL_STRING_LEN( wssURL, endpoints.wssEndpoint.pEndpoint, strlen( wssURL ) );
-    TEST_ASSERT_EQUAL( strlen( httpsURL ),
+    TEST_ASSERT_EQUAL_STRING_LEN( expectedWssURL,
+                                  endpoints.wssEndpoint.pEndpoint,
+                                  endpoints.wssEndpoint.endpointLength );
+    TEST_ASSERT_EQUAL( strlen( expectedHttpsURL ),
                        endpoints.httpsEndpoint.endpointLength );
-    TEST_ASSERT_EQUAL_STRING_LEN( httpsURL, endpoints.httpsEndpoint.pEndpoint, strlen( httpsURL ) );
-    TEST_ASSERT_EQUAL( strlen( webrtcURL ),
+    TEST_ASSERT_EQUAL_STRING_LEN( expectedHttpsURL,
+                                  endpoints.httpsEndpoint.pEndpoint,
+                                  endpoints.httpsEndpoint.endpointLength );
+    TEST_ASSERT_EQUAL( strlen( expectedWebrtcURL ),
                        endpoints.webrtcEndpoint.endpointLength );
-    TEST_ASSERT_EQUAL_STRING_LEN( webrtcURL, endpoints.webrtcEndpoint.pEndpoint, strlen( webrtcURL ) );
+    TEST_ASSERT_EQUAL_STRING_LEN( expectedWebrtcURL,
+                                  endpoints.webrtcEndpoint.pEndpoint,
+                                  endpoints.webrtcEndpoint.endpointLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -2604,7 +2654,8 @@ void test_signaling_ConstructGetIceServerConfigRequest_BadParams( void )
     SignalingResult_t result;
 
     result = Signaling_ConstructGetIceServerConfigRequest( NULL,
-                                                           &( iceServerConfigRequestInfo ), &( requestBuffer ) );
+                                                           &( iceServerConfigRequestInfo ),
+                                                           &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -2614,7 +2665,8 @@ void test_signaling_ConstructGetIceServerConfigRequest_BadParams( void )
     endpoint.pEndpoint = NULL;
 
     result = Signaling_ConstructGetIceServerConfigRequest( &( endpoint ),
-                                                           &( iceServerConfigRequestInfo ), &( requestBuffer ) );
+                                                           &( iceServerConfigRequestInfo ),
+                                                           &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -2624,7 +2676,8 @@ void test_signaling_ConstructGetIceServerConfigRequest_BadParams( void )
     endpoint.pEndpoint = "https://example.com";
 
     result = Signaling_ConstructGetIceServerConfigRequest( &( endpoint ),
-                                                           &( iceServerConfigRequestInfo ), NULL );
+                                                           &( iceServerConfigRequestInfo ),
+                                                           NULL );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -2632,15 +2685,19 @@ void test_signaling_ConstructGetIceServerConfigRequest_BadParams( void )
     /*      <------------------------------------------------------------------------------------------>      */
 
     result = Signaling_ConstructGetIceServerConfigRequest( &( endpoint ),
-                                                           NULL, &( requestBuffer ) );
+                                                           NULL,
+                                                           &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     /*      <------------------------------------------------------------------------------------------>      */
+
     requestBuffer.pUrl = NULL;
+
     result = Signaling_ConstructGetIceServerConfigRequest( &( endpoint ),
-                                                           &( iceServerConfigRequestInfo ), &( requestBuffer ) );
+                                                           &( iceServerConfigRequestInfo ),
+                                                           &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -2650,8 +2707,10 @@ void test_signaling_ConstructGetIceServerConfigRequest_BadParams( void )
     requestBuffer.pUrl = "https://kinesisvideo.cn-east-1.amazonaws.com.cn/describeSignalingChannel";
     requestBuffer.urlLength = strlen( requestBuffer.pUrl );
     requestBuffer.pBody = NULL;
+
     result = Signaling_ConstructGetIceServerConfigRequest( &( endpoint ),
-                                                           &( iceServerConfigRequestInfo ), &( requestBuffer ) );
+                                                           &( iceServerConfigRequestInfo ),
+                                                           &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -2661,8 +2720,10 @@ void test_signaling_ConstructGetIceServerConfigRequest_BadParams( void )
     requestBuffer.pBody = "{\"ChannelName\":\"Test-Channel-China\"}";
     requestBuffer.bodyLength = strlen( requestBuffer.pBody );
     iceServerConfigRequestInfo.pClientId = NULL;
+
     result = Signaling_ConstructGetIceServerConfigRequest( &( endpoint ),
-                                                           &( iceServerConfigRequestInfo ), &( requestBuffer ) );
+                                                           &( iceServerConfigRequestInfo ),
+                                                           &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -2678,9 +2739,9 @@ void test_signaling_ConstructGetIceServerConfigRequest_URLOutofMemory( void )
     SignalingChannelEndpoint_t endpoint = { 0 };
     GetIceServerConfigRequestInfo_t iceServerConfigRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
-    char urlBuffer[ 20 ];                                       /* The url buffer is small */
-    char bodyBuffer[ 500 ];
     SignalingResult_t result;
+    char urlBuffer[ 20 ]; /* The url buffer is too small to fit the complete URL. */
+    char bodyBuffer[ 500 ];
 
     endpoint.pEndpoint = "https://example.com";
     endpoint.endpointLength = strlen( endpoint.pEndpoint );
@@ -2690,13 +2751,14 @@ void test_signaling_ConstructGetIceServerConfigRequest_URLOutofMemory( void )
     iceServerConfigRequestInfo.pClientId = "Test-Client-Id";
     iceServerConfigRequestInfo.clientIdLength = strlen( iceServerConfigRequestInfo.pClientId );
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructGetIceServerConfigRequest( &( endpoint ),
-                                                           &( iceServerConfigRequestInfo ), &( requestBuffer ) );
+                                                           &( iceServerConfigRequestInfo ),
+                                                           &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
                        result );
@@ -2712,9 +2774,9 @@ void test_signaling_ConstructGetIceServerConfigRequest_BodyOutofMemory( void )
     SignalingChannelEndpoint_t endpoint = { 0 };
     GetIceServerConfigRequestInfo_t iceServerConfigRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
-    char urlBuffer[ 200 ];
-    char bodyBuffer[ 10 ];           /* The body buffer is small */
     SignalingResult_t result;
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 10 ]; /* The body buffer is too small to fit the complete body. */
 
     endpoint.pEndpoint = "https://example.com";
     endpoint.endpointLength = strlen( endpoint.pEndpoint );
@@ -2724,13 +2786,14 @@ void test_signaling_ConstructGetIceServerConfigRequest_BodyOutofMemory( void )
     iceServerConfigRequestInfo.pClientId = "Test-Client-Id";
     iceServerConfigRequestInfo.clientIdLength = strlen( iceServerConfigRequestInfo.pClientId );
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructGetIceServerConfigRequest( &( endpoint ),
-                                                           &( iceServerConfigRequestInfo ), &( requestBuffer ) );
+                                                           &( iceServerConfigRequestInfo ),
+                                                           &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
                        result );
@@ -2746,15 +2809,16 @@ void test_signaling_ConstructGetIceServerConfigRequest( void )
     SignalingChannelEndpoint_t endpoint = { 0 };
     GetIceServerConfigRequestInfo_t iceServerConfigRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
     char urlBuffer[ 200 ];
     char bodyBuffer[ 500 ];
-    SignalingResult_t result;
     const char * pExpectedUrl = "https://example.com/v1/get-ice-server-config";
-    const char * pExpectedBody = "{"
-                                    "\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\","
-                                    "\"ClientId\":\"Test-Client-Id\","
-                                    "\"Service\":\"TURN\""
-                                  "}";
+    const char * pExpectedBody =
+    "{"
+        "\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\","
+        "\"ClientId\":\"Test-Client-Id\","
+        "\"Service\":\"TURN\""
+    "}";
 
     endpoint.pEndpoint = "https://example.com";
     endpoint.endpointLength = strlen( endpoint.pEndpoint );
@@ -2764,24 +2828,27 @@ void test_signaling_ConstructGetIceServerConfigRequest( void )
     iceServerConfigRequestInfo.pClientId = "Test-Client-Id";
     iceServerConfigRequestInfo.clientIdLength = strlen( iceServerConfigRequestInfo.pClientId );
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructGetIceServerConfigRequest( &( endpoint ),
-                                                           &( iceServerConfigRequestInfo ), &( requestBuffer ) );
+                                                           &( iceServerConfigRequestInfo ),
+                                                           &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
                        requestBuffer.urlLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
-                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
+                                  requestBuffer.pUrl,
+                                  requestBuffer.urlLength );
     TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
                        requestBuffer.bodyLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
-                              requestBuffer.pBody );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedBody,
+                                  requestBuffer.pBody,
+                                  requestBuffer.bodyLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -2791,26 +2858,32 @@ void test_signaling_ConstructGetIceServerConfigRequest( void )
  */
 void test_signaling_ParseGetIceServerConfigResponse_BadParams( void )
 {
-    const char * message = "Valid-Message";
-    size_t messageLength = strlen( message );
     SignalingIceServer_t iceServers;
     size_t numIceServers;
     SignalingResult_t result;
+    const char * message = "Valid-Message";
+    size_t messageLength = strlen( message );
 
     result = Signaling_ParseGetIceServerConfigResponse( NULL,
-                                                        messageLength, &( iceServers ), &( numIceServers ) );
+                                                        messageLength,
+                                                        &( iceServers ),
+                                                        &( numIceServers ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     result = Signaling_ParseGetIceServerConfigResponse( message,
-                                                        messageLength, NULL, &( numIceServers ) );
+                                                        messageLength,
+                                                        NULL,
+                                                        &( numIceServers ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     result = Signaling_ParseGetIceServerConfigResponse( message,
-                                                        messageLength, &( iceServers ), NULL );
+                                                        messageLength,
+                                                        &( iceServers ),
+                                                        NULL );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -2826,25 +2899,27 @@ void test_signaling_ParseGetIceServerConfigResponse_InvalidJson( void )
     SignalingIceServer_t iceServers[ 1 ];
     size_t numIceServers = 1;
     SignalingResult_t result;
-    const char * message = "{\"IceServerList\": [";             /* Missing closing bracket */
+    const char * message = "{\"IceServerList\": ["; /* Missing closing bracket. */
     size_t messageLength = strlen( message );
 
 
     result = Signaling_ParseGetIceServerConfigResponse( message,
-                                                        messageLength, &( iceServers[ 0 ] ), &( numIceServers ) );
+                                                        messageLength,
+                                                        &( iceServers[ 0 ] ),
+                                                        &( numIceServers ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
                        result );
 
     /*<----------------------------------------------------------------->*/
 
-    const char * message2 = "{"                      /* Empty JSON */
-                            "}";
+    const char * message2 = "{}"; /* Empty JSON. */
     size_t messageLength2 = strlen( message2 );
 
-
     result = Signaling_ParseGetIceServerConfigResponse( message2,
-                                                        messageLength2, &( iceServers[ 0 ] ), &( numIceServers ) );
+                                                        messageLength2,
+                                                        &( iceServers[ 0 ] ),
+                                                        &( numIceServers ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
                        result );
@@ -2860,29 +2935,34 @@ void test_signaling_ParseGetIceServerConfigResponse_UnexpectedResponse( void )
     SignalingIceServer_t iceServers[ 1 ];
     size_t numIceServers = 1;
     SignalingResult_t result;
-    const char * message = "{"
-        "\"IceServerList\": {"          /* Opening Bracket Not JSON Array Type */
+    const char * message =
+    "{"
+        "\"IceServerList\":"
+        "{" /* Not JSON Array Type. */
             "{"
                 "\"Password\": \"password123\","
                 "\"Ttl\": 300,"
                 "\"Uris\": [\"turn:example.com:3478\"],"
                 "\"Username\": \"username123\""
             "}"
-        "}"                             /* Closing Bracket not Not JSON Array Type */
+        "}"
     "}";
     size_t messageLength = strlen( message );
 
-
     result = Signaling_ParseGetIceServerConfigResponse( message,
-                                                        messageLength, &( iceServers[ 0 ] ), &( numIceServers ) );
+                                                        messageLength,
+                                                        &( iceServers[ 0 ] ),
+                                                        &( numIceServers ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
 
     /*<----------------------------------------------------------------->*/
 
-    const char * message2 = "{"
-        "\"Unkown\": ["                  /* Unkown Key */
+    const char * message2 =
+    "{"
+        "\"Unkown\":" /* Unkown key. */
+        "["
             "{"
                 "\"Password\": \"password123\","
                 "\"Ttl\": 300,"
@@ -2893,21 +2973,23 @@ void test_signaling_ParseGetIceServerConfigResponse_UnexpectedResponse( void )
     "}";
     size_t messageLength2 = strlen( message2 );
 
-
     result = Signaling_ParseGetIceServerConfigResponse( message2,
-                                                        messageLength2, &( iceServers[ 0 ] ), &( numIceServers ) );
+                                                        messageLength2,
+                                                        &( iceServers[ 0 ] ),
+                                                        &( numIceServers ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
 
     /*<----------------------------------------------------------------->*/
 
-    const char * message3 = "{\"UnexpectedKey\": []}";               /* Unkown Key Though the length of "IceServerList" == "UnexpectedKey" */
+    const char * message3 = "{\"UnexpectedKey\": []}"; /* Unkown Key Though the length of "IceServerList" == "UnexpectedKey". */
     size_t messageLength3 = strlen( message3 );
 
-
     result = Signaling_ParseGetIceServerConfigResponse( message3,
-                                                        messageLength3, &( iceServers[ 0 ] ), &( numIceServers ) );
+                                                        messageLength3,
+                                                        &( iceServers[ 0 ] ),
+                                                        &( numIceServers ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
@@ -2918,16 +3000,18 @@ void test_signaling_ParseGetIceServerConfigResponse_UnexpectedResponse( void )
 /**
  * @brief Validate Signaling Parse Ice Server Config Response functionality.
  */
-void test_signaling_ParseGetIceServerConfigResponse_Parsing_InvalidTTL( void )
+void test_signaling_ParseGetIceServerConfigResponse_InvalidTtl( void )
 {
     SignalingIceServer_t iceServers[ 1 ];
     size_t numIceServers = 1;
     SignalingResult_t result;
-    const char * message = "{"
-        "\"IceServerList\": ["
+    const char * message =
+    "{"
+        "\"IceServerList\":"
+        "["
             "{"
                 "\"Password\": \"password123\","
-                "\"Ttl\": 30000000,"                                /* TTL value length > SIGNALING_ICE_SERVER_TTL_SECONDS_BUFFER_MAX ( 7 ) */
+                "\"Ttl\": 30000000," /* TTL value length > SIGNALING_ICE_SERVER_TTL_SECONDS_BUFFER_MAX ( 7 ). */
                 "\"Uris\": [\"turn:example.com:3478\"],"
                 "\"Username\": \"username123\""
             "}"
@@ -2935,9 +3019,10 @@ void test_signaling_ParseGetIceServerConfigResponse_Parsing_InvalidTTL( void )
     "}";
     size_t messageLength = strlen( message );
 
-
     result = Signaling_ParseGetIceServerConfigResponse( message,
-                                                        messageLength, &( iceServers[ 0 ] ), &( numIceServers ) );
+                                                        messageLength,
+                                                        &( iceServers[ 0 ] ),
+                                                        &( numIceServers ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_TTL,
                        result );
@@ -2948,16 +3033,18 @@ void test_signaling_ParseGetIceServerConfigResponse_Parsing_InvalidTTL( void )
 /**
  * @brief Validate Signaling Parse Ice Server Config Response functionality.
  */
-void test_signaling_ParseGetIceServerConfigResponse_Parsing_LowTTL( void )
+void test_signaling_ParseGetIceServerConfigResponse_LowTtl( void )
 {
     SignalingIceServer_t iceServers[ 1 ];
     size_t numIceServers = 1;
     SignalingResult_t result;
-    const char * message = "{"
-        "\"IceServerList\": ["
+    const char * message =
+    "{"
+        "\"IceServerList\":"
+        "["
             "{"
                 "\"Password\": \"password123\","
-                "\"Ttl\": 15,"                                    /* TTL value < SIGNALING_ICE_SERVER_TTL_SECONDS_MIN (30) */
+                "\"Ttl\": 15," /* TTL value < SIGNALING_ICE_SERVER_TTL_SECONDS_MIN (30). */
                 "\"Uris\": [\"turn:example.com:3478\"],"
                 "\"Username\": \"username123\""
             "}"
@@ -2965,9 +3052,10 @@ void test_signaling_ParseGetIceServerConfigResponse_Parsing_LowTTL( void )
     "}";
     size_t messageLength = strlen( message );
 
-
     result = Signaling_ParseGetIceServerConfigResponse( message,
-                                                        messageLength, &( iceServers[ 0 ] ), &( numIceServers ) );
+                                                        messageLength,
+                                                        &( iceServers[ 0 ] ),
+                                                        &( numIceServers ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_TTL,
                        result );
@@ -2978,16 +3066,18 @@ void test_signaling_ParseGetIceServerConfigResponse_Parsing_LowTTL( void )
 /**
  * @brief Validate Signaling Parse Ice Server Config Response functionality.
  */
-void test_signaling_ParseGetIceServerConfigResponse_Parsing_HighTTL( void )
+void test_signaling_ParseGetIceServerConfigResponse_HighTtl( void )
 {
     SignalingIceServer_t iceServers[ 1 ];
     size_t numIceServers = 1;
     SignalingResult_t result;
-    const char * message = "{"
-        "\"IceServerList\": ["
+    const char * message =
+    "{"
+        "\"IceServerList\":"
+        "["
             "{"
                 "\"Password\": \"password123\","
-                "\"Ttl\": 86411,"                                   /* TTL value > SIGNALING_ICE_SERVER_TTL_SECONDS_MAX ( 86400 ) */
+                "\"Ttl\": 86411," /* TTL value > SIGNALING_ICE_SERVER_TTL_SECONDS_MAX ( 86400 ). */
                 "\"Uris\": [\"turn:example.com:3478\"],"
                 "\"Username\": \"username123\""
             "}"
@@ -2995,9 +3085,10 @@ void test_signaling_ParseGetIceServerConfigResponse_Parsing_HighTTL( void )
     "}";
     size_t messageLength = strlen( message );
 
-
     result = Signaling_ParseGetIceServerConfigResponse( message,
-                                                        messageLength, &( iceServers[ 0 ] ), &( numIceServers ) );
+                                                        messageLength,
+                                                        &( iceServers[ 0 ] ),
+                                                        &( numIceServers ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_TTL,
                        result );
@@ -3013,31 +3104,49 @@ void test_signaling_ParseGetIceServerConfigResponse( void )
     SignalingIceServer_t iceServers[ 1 ];
     size_t numIceServers = 1;
     SignalingResult_t result;
-    const char * message = "{"
-        "\"IceServerList\": ["
+    const char * message =
+    "{"
+        "\"IceServerList\":"
+        "["
             "{"
                 "\"Password\": \"password123\","
                 "\"Ttl\": 300,"
                 "\"Uris\": [\"turn:example.com:3478\"],"
                 "\"Username\": \"username123\","
-                "\"Unkown\": \"Unkown-Value\""              /* This Unkown Tag will be ignored. */
+                "\"Unkown\": \"Unkown-Value\"" /* This Unkown Tag will be ignored. */
             "}"
         "]"
     "}";
     size_t messageLength = strlen( message );
 
-
     result = Signaling_ParseGetIceServerConfigResponse( message,
-                                                        messageLength, &( iceServers[ 0 ] ), &( numIceServers ) );
+                                                        messageLength,
+                                                        &( iceServers[ 0 ] ),
+                                                        &( numIceServers ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL( 1, numIceServers );
-    TEST_ASSERT_EQUAL_STRING_LEN( "password123", iceServers[ 0 ].pPassword, iceServers[ 0 ].passwordLength );
-    TEST_ASSERT_EQUAL( 300, iceServers[ 0 ].messageTtlSeconds );
-    TEST_ASSERT_EQUAL( 1, iceServers[ 0 ].urisNum );
-    TEST_ASSERT_EQUAL_STRING_LEN( "turn:example.com:3478", iceServers[ 0 ].pUris[ 0 ], iceServers[ 0 ].urisLength[ 0 ] );
-    TEST_ASSERT_EQUAL_STRING_LEN( "username123", iceServers[ 0 ].pUserName, iceServers[ 0 ].userNameLength );
+    TEST_ASSERT_EQUAL( 1,
+                       numIceServers );
+    TEST_ASSERT_EQUAL( strlen( "password123" ),
+                       iceServers[ 0 ].passwordLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "password123",
+                                  iceServers[ 0 ].pPassword,
+                                  iceServers[ 0 ].passwordLength );
+    TEST_ASSERT_EQUAL( 300,
+                       iceServers[ 0 ].messageTtlSeconds );
+    TEST_ASSERT_EQUAL( 1,
+                        iceServers[ 0 ].urisNum );
+    TEST_ASSERT_EQUAL( strlen( "turn:example.com:3478" ),
+                       iceServers[ 0 ].urisLength[ 0 ] );
+    TEST_ASSERT_EQUAL_STRING_LEN( "turn:example.com:3478",
+                                  iceServers[ 0 ].pUris[ 0 ],
+                                  iceServers[ 0 ].urisLength[ 0 ] );
+    TEST_ASSERT_EQUAL( strlen( "username123" ),
+                       iceServers[ 0 ].userNameLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "username123",
+                                  iceServers[ 0 ].pUserName,
+                                  iceServers[ 0 ].userNameLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -3050,19 +3159,24 @@ void test_signaling_ParseGetIceServerConfigResponse_Empty( void )
     SignalingIceServer_t iceServers[ 1 ];
     size_t numIceServers = 1;
     SignalingResult_t result;
-    const char * message = "{"
-        "\"IceServerList\": ["
-                                /* Empty Buffer will be ignored. */
+    const char * message =
+    "{"
+        "\"IceServerList\":"
+        "["
+            /* Empty Buffer will be ignored. */
         "]"
     "}";
     size_t messageLength = strlen( message );
 
-
     result = Signaling_ParseGetIceServerConfigResponse( message,
-                                                        messageLength, &( iceServers[ 0 ] ), &( numIceServers ) );
+                                                        messageLength,
+                                                        &( iceServers[ 0 ] ),
+                                                        &( numIceServers ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
+    TEST_ASSERT_EQUAL( 0,
+                       numIceServers );
 }
 
 /*-----------------------------------------------------------*/
@@ -3078,7 +3192,8 @@ void test_signaling_ConstructJoinStorageSessionRequest_BadParams( void )
     SignalingResult_t result;
 
     result = Signaling_ConstructJoinStorageSessionRequest( NULL,
-                                                           &( joinStorageSessionRequestInfo ), &( requestBuffer ) );
+                                                           &( joinStorageSessionRequestInfo ),
+                                                           &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -3086,8 +3201,10 @@ void test_signaling_ConstructJoinStorageSessionRequest_BadParams( void )
     /*      <------------------------------------------------------------------------------------------>      */
 
     webrtcEndpoint.pEndpoint = NULL;
+
     result = Signaling_ConstructJoinStorageSessionRequest( &( webrtcEndpoint ),
-                                                           &( joinStorageSessionRequestInfo ), &( requestBuffer ) );
+                                                           &( joinStorageSessionRequestInfo ),
+                                                           &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -3098,7 +3215,8 @@ void test_signaling_ConstructJoinStorageSessionRequest_BadParams( void )
     webrtcEndpoint.endpointLength = strlen( webrtcEndpoint.pEndpoint );
 
     result = Signaling_ConstructJoinStorageSessionRequest( &( webrtcEndpoint ),
-                                                           &( joinStorageSessionRequestInfo ), NULL );
+                                                           &( joinStorageSessionRequestInfo ),
+                                                           NULL );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -3108,15 +3226,19 @@ void test_signaling_ConstructJoinStorageSessionRequest_BadParams( void )
 
 
     result = Signaling_ConstructJoinStorageSessionRequest( &( webrtcEndpoint ),
-                                                           NULL, &( requestBuffer ) );
+                                                           NULL,
+                                                           &( requestBuffer ) );
+
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     /*      <------------------------------------------------------------------------------------------>      */
 
     requestBuffer.pUrl = NULL;
+
     result = Signaling_ConstructJoinStorageSessionRequest( &( webrtcEndpoint ),
-                                                           &( joinStorageSessionRequestInfo ), &( requestBuffer ) );
+                                                           &( joinStorageSessionRequestInfo ),
+                                                           &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -3128,7 +3250,8 @@ void test_signaling_ConstructJoinStorageSessionRequest_BadParams( void )
     requestBuffer.pBody = NULL;
 
     result = Signaling_ConstructJoinStorageSessionRequest( &( webrtcEndpoint ),
-                                                           &( joinStorageSessionRequestInfo ), &( requestBuffer ) );
+                                                           &( joinStorageSessionRequestInfo ),
+                                                           &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -3140,7 +3263,8 @@ void test_signaling_ConstructJoinStorageSessionRequest_BadParams( void )
     joinStorageSessionRequestInfo.channelArn.pChannelArn = NULL;
 
     result = Signaling_ConstructJoinStorageSessionRequest( &( webrtcEndpoint ),
-                                                           &( joinStorageSessionRequestInfo ), &( requestBuffer ) );
+                                                           &( joinStorageSessionRequestInfo ),
+                                                           &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -3156,13 +3280,14 @@ void test_signaling_ConstructJoinStorageSessionRequest_Master( void )
     SignalingChannelEndpoint_t webrtcEndpoint = { 0 };
     JoinStorageSessionRequestInfo_t joinStorageSessionRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
     char urlBuffer[ 200 ];
     char bodyBuffer[ 500 ];
-    SignalingResult_t result;
     const char * pExpectedUrl = "webrtc://example.com/joinStorageSession";
-    const char * pExpectedBody = "{"
-                                    "\"channelArn\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\""
-                                  "}";
+    const char * pExpectedBody =
+    "{"
+        "\"channelArn\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\""
+    "}";
 
     webrtcEndpoint.pEndpoint = "webrtc://example.com";
     webrtcEndpoint.endpointLength = strlen( webrtcEndpoint.pEndpoint );
@@ -3173,24 +3298,28 @@ void test_signaling_ConstructJoinStorageSessionRequest_Master( void )
     joinStorageSessionRequestInfo.clientIdLength = 0;
     joinStorageSessionRequestInfo.role = SIGNALING_ROLE_MASTER;
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructJoinStorageSessionRequest( &( webrtcEndpoint ),
-                                                           &( joinStorageSessionRequestInfo ), &( requestBuffer ) );
+                                                           &( joinStorageSessionRequestInfo ),
+                                                           &( requestBuffer ) );
 
-    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK, result );
-    TEST_ASSERT_TRUE( strstr( requestBuffer.pBody, "\"clientId\"" ) == NULL );
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_NULL( strstr( requestBuffer.pBody, "\"clientId\"" ) );
     TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
                        requestBuffer.urlLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
-                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
+                                  requestBuffer.pUrl,
+                                  requestBuffer.urlLength );
     TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
                        requestBuffer.bodyLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
-                              requestBuffer.pBody );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedBody,
+                                  requestBuffer.pBody,
+                                  requestBuffer.bodyLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -3203,14 +3332,15 @@ void test_signaling_ConstructJoinStorageSessionRequest_Viewer( void )
     SignalingChannelEndpoint_t webrtcEndpoint = { 0 };
     JoinStorageSessionRequestInfo_t joinStorageSessionRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
     char urlBuffer[ 200 ];
     char bodyBuffer[ 500 ];
-    SignalingResult_t result;
     const char * pExpectedUrl = "webrtc://example.com/joinStorageSession";
-    const char * pExpectedBody = "{"
-                                    "\"channelArn\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\","
-                                    "\"clientId\":\"TestClient\""
-                                  "}";
+    const char * pExpectedBody =
+    "{"
+        "\"channelArn\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\","
+        "\"clientId\":\"TestClient\""
+    "}";
 
     webrtcEndpoint.pEndpoint = "webrtc://example.com";
     webrtcEndpoint.endpointLength = strlen( webrtcEndpoint.pEndpoint );
@@ -3221,23 +3351,27 @@ void test_signaling_ConstructJoinStorageSessionRequest_Viewer( void )
     joinStorageSessionRequestInfo.clientIdLength = strlen( joinStorageSessionRequestInfo.pClientId );
     joinStorageSessionRequestInfo.role = SIGNALING_ROLE_VIEWER;
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructJoinStorageSessionRequest( &( webrtcEndpoint ),
-                                                           &( joinStorageSessionRequestInfo ), &( requestBuffer ) );
+                                                           &( joinStorageSessionRequestInfo ),
+                                                           &( requestBuffer ) );
 
-    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK, result );
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
     TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
                        requestBuffer.urlLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
-                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
+                                  requestBuffer.pUrl,
+                                  requestBuffer.urlLength );
     TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
                        requestBuffer.bodyLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
-                              requestBuffer.pBody );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedBody,
+                                  requestBuffer.pBody,
+                                  requestBuffer.bodyLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -3245,14 +3379,14 @@ void test_signaling_ConstructJoinStorageSessionRequest_Viewer( void )
 /**
  * @brief Validate Signaling Construct Join Storage Session Request functionality.
  */
-void test_signaling_ConstructJoinStorageSessionRequest_URLOutofMemory( void )
+void test_signaling_ConstructJoinStorageSessionRequest_UrlOutofMemory( void )
 {
     SignalingChannelEndpoint_t webrtcEndpoint = { 0 };
     JoinStorageSessionRequestInfo_t joinStorageSessionRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
-    char urlBuffer[ 10 ];                    /* The url buffer is small */
-    char bodyBuffer[ 500 ];
     SignalingResult_t result;
+    char urlBuffer[ 10 ]; /* The url buffer is too small to fit the complete URL. */
+    char bodyBuffer[ 500 ];
 
     webrtcEndpoint.pEndpoint = "webrtc://example.com";
     webrtcEndpoint.endpointLength = strlen( webrtcEndpoint.pEndpoint );
@@ -3262,13 +3396,14 @@ void test_signaling_ConstructJoinStorageSessionRequest_URLOutofMemory( void )
     joinStorageSessionRequestInfo.pClientId = "TestClient";
     joinStorageSessionRequestInfo.clientIdLength = strlen( joinStorageSessionRequestInfo.pClientId );
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructJoinStorageSessionRequest( &( webrtcEndpoint ),
-                                                           &( joinStorageSessionRequestInfo ), &( requestBuffer ) );
+                                                           &( joinStorageSessionRequestInfo ),
+                                                           &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY, result );
 }
@@ -3283,9 +3418,9 @@ void test_signaling_ConstructJoinStorageSessionRequest_BodyOutofMemory( void )
     SignalingChannelEndpoint_t webrtcEndpoint = { 0 };
     JoinStorageSessionRequestInfo_t joinStorageSessionRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
-    char urlBuffer[ 200 ];
-    char bodyBuffer[ 10 ];                      /* The body buffer is small */
     SignalingResult_t result;
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 10 ]; /* The body buffer is too small to fit the complete body. */
 
     webrtcEndpoint.pEndpoint = "webrtc://example.com";
     webrtcEndpoint.endpointLength = strlen( webrtcEndpoint.pEndpoint );
@@ -3295,15 +3430,17 @@ void test_signaling_ConstructJoinStorageSessionRequest_BodyOutofMemory( void )
     joinStorageSessionRequestInfo.pClientId = "TestClient";
     joinStorageSessionRequestInfo.clientIdLength = strlen( joinStorageSessionRequestInfo.pClientId );
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructJoinStorageSessionRequest( &( webrtcEndpoint ),
-                                                           &( joinStorageSessionRequestInfo ), &( requestBuffer ) );
+                                                           &( joinStorageSessionRequestInfo ),
+                                                           &( requestBuffer ) );
 
-    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY, result );
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
+                       result );
 }
 
 /*-----------------------------------------------------------*/
@@ -3319,7 +3456,8 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_BadParams( void )
     SignalingResult_t result;
 
     result = Signaling_ConstructDeleteSignalingChannelRequest( NULL,
-                                                               &( deleteSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( deleteSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -3327,8 +3465,10 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_BadParams( void )
     /*      <------------------------------------------------------------------------------------------>      */
 
     awsRegion.pAwsRegion = NULL;
+
     result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
-                                                               &( deleteSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( deleteSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -3339,25 +3479,28 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_BadParams( void )
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
 
     result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
-                                                               &( deleteSignalingChannelRequestInfo ), NULL );
+                                                               &( deleteSignalingChannelRequestInfo ),
+                                                               NULL );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     /*      <------------------------------------------------------------------------------------------>      */
 
-
-
     result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
-                                                               NULL, &( requestBuffer ) );
+                                                               NULL,
+                                                               &( requestBuffer ) );
+
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     /*      <------------------------------------------------------------------------------------------>      */
 
     requestBuffer.pUrl = NULL;
+
     result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
-                                                               &( deleteSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( deleteSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -3369,7 +3512,8 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_BadParams( void )
     requestBuffer.pBody = NULL;
 
     result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
-                                                               &( deleteSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( deleteSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -3381,7 +3525,8 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_BadParams( void )
     deleteSignalingChannelRequestInfo.channelArn.pChannelArn = NULL;
 
     result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
-                                                               &( deleteSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( deleteSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -3393,7 +3538,8 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_BadParams( void )
     deleteSignalingChannelRequestInfo.pVersion = NULL;
 
     result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
-                                                               &( deleteSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( deleteSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -3426,9 +3572,9 @@ void test_signaling_ConstructDeleteSignalingChannelRequest( void )
     deleteSignalingChannelRequestInfo.pVersion = "1.0.0";
     deleteSignalingChannelRequestInfo.versionLength = strlen( deleteSignalingChannelRequestInfo.pVersion );
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
@@ -3473,9 +3619,9 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_ChinaRegion( void )
     deleteSignalingChannelRequestInfo.pVersion = "2.0.0";
     deleteSignalingChannelRequestInfo.versionLength = strlen( deleteSignalingChannelRequestInfo.pVersion );
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
@@ -3520,9 +3666,9 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_SmallLengthRegion( vo
     deleteSignalingChannelRequestInfo.pVersion = "2.0.0";
     deleteSignalingChannelRequestInfo.versionLength = strlen( deleteSignalingChannelRequestInfo.pVersion );
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
@@ -3562,9 +3708,9 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_URL_OutofMemory( void
     deleteSignalingChannelRequestInfo.pVersion = "2.0.0";
     deleteSignalingChannelRequestInfo.versionLength = strlen( deleteSignalingChannelRequestInfo.pVersion );
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
@@ -3596,9 +3742,9 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_Body_OutofMemory( voi
     deleteSignalingChannelRequestInfo.pVersion = "2.0.0";
     deleteSignalingChannelRequestInfo.versionLength = strlen( deleteSignalingChannelRequestInfo.pVersion );
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
-    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
@@ -3723,7 +3869,7 @@ void test_signaling_ConstructConnectWssEndpointRequest_Master( void )
     connectWssEndpointRequestInfo.pClientId = NULL;
     connectWssEndpointRequestInfo.clientIdLength = 0;
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
     requestBuffer.pBody = NULL;
     requestBuffer.bodyLength = 0;
@@ -3763,7 +3909,7 @@ void test_signaling_ConstructConnectWssEndpointRequest_Viewer( void )
     connectWssEndpointRequestInfo.pClientId = "TestClient";
     connectWssEndpointRequestInfo.clientIdLength = strlen( connectWssEndpointRequestInfo.pClientId );
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
     requestBuffer.pBody = NULL;
     requestBuffer.bodyLength = 0;
@@ -3802,7 +3948,7 @@ void test_signaling_ConstructConnectWssEndpointRequest_Url_OutofMemory( void )
     connectWssEndpointRequestInfo.pClientId = "TestClient";
     connectWssEndpointRequestInfo.clientIdLength = strlen( connectWssEndpointRequestInfo.pClientId );
 
-    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
     requestBuffer.pBody = NULL;
     requestBuffer.bodyLength = 0;

--- a/test/unit-test/signaling_api/signaling_api_utest.c
+++ b/test/unit-test/signaling_api/signaling_api_utest.c
@@ -98,9 +98,10 @@ void test_signaling_ConstructDescribeSignalingChannelRequest( void )
     char urlBuffer[ 200 ];
     char bodyBuffer[ 100 ];
     const char * pExpectedUrl = "https://kinesisvideo.us-east-1.amazonaws.com/describeSignalingChannel";
-    const char * pExpectedBody = "{"
-                                    "\"ChannelName\":\"Test-Channel\""
-                                  "}";
+    const char * pExpectedBody =
+    "{"
+        "\"ChannelName\":\"Test-Channel\""
+    "}";
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -121,12 +122,14 @@ void test_signaling_ConstructDescribeSignalingChannelRequest( void )
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
                        requestBuffer.urlLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
-                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
+                                  requestBuffer.pUrl,
+                                  requestBuffer.urlLength );
     TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
                        requestBuffer.bodyLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
-                              requestBuffer.pBody );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedBody,
+                                  requestBuffer.pBody,
+                                  requestBuffer.bodyLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -143,9 +146,10 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_SmallLengthRegion( 
     char urlBuffer[ 200 ];
     char bodyBuffer[ 100 ];
     const char * pExpectedUrl = "https://kinesisvideo.ca.amazonaws.com/describeSignalingChannel";
-    const char * pExpectedBody = "{"
-                                    "\"ChannelName\":\"Test-Channel-China\""
-                                  "}";
+    const char * pExpectedBody =
+    "{"
+        "\"ChannelName\":\"Test-Channel-China\""
+    "}";
 
     awsRegion.pAwsRegion = "ca"; /* The Region Length is < 3. */
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -166,12 +170,14 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_SmallLengthRegion( 
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
                        requestBuffer.urlLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
-                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
+                                  requestBuffer.pUrl,
+                                  requestBuffer.urlLength );
     TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
                        requestBuffer.bodyLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
-                              requestBuffer.pBody );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedBody,
+                                  requestBuffer.pBody,
+                                  requestBuffer.bodyLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -188,9 +194,10 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_ChinaRegion( void )
     char urlBuffer[ 200 ];
     char bodyBuffer[ 100 ];
     const char * pExpectedUrl = "https://kinesisvideo.cn-east-1.amazonaws.com.cn/describeSignalingChannel";
-    const char * pExpectedBody = "{"
-                                    "\"ChannelName\":\"Test-Channel-China\""
-                                  "}";
+    const char * pExpectedBody =
+    "{"
+        "\"ChannelName\":\"Test-Channel-China\""
+    "}";
 
     awsRegion.pAwsRegion = "cn-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -211,12 +218,14 @@ void test_signaling_ConstructDescribeSignalingChannelRequest_ChinaRegion( void )
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
                        requestBuffer.urlLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
-                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
+                                  requestBuffer.pUrl,
+                                  requestBuffer.urlLength );
     TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
                        requestBuffer.bodyLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
-                              requestBuffer.pBody );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedBody,
+                                  requestBuffer.pBody,
+                                  requestBuffer.bodyLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -294,8 +303,8 @@ void test_signaling_ParseDescribeSignalingChannelResponse_BadParams( void )
 {
     SignalingChannelInfo_t channelInfo;
     SignalingResult_t result;
-    const char * message = "Input Message";
-    size_t messageLength = strlen( message );
+    const char * pMessage = "Input Message";
+    size_t messageLength = strlen( pMessage );
 
     result = Signaling_ParseDescribeSignalingChannelResponse( NULL,
                                                               messageLength,
@@ -304,7 +313,7 @@ void test_signaling_ParseDescribeSignalingChannelResponse_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    result = Signaling_ParseDescribeSignalingChannelResponse( message,
+    result = Signaling_ParseDescribeSignalingChannelResponse( pMessage,
                                                               messageLength,
                                                               NULL );
 
@@ -321,10 +330,10 @@ void test_signaling_ParseDescribeSignalingChannelResponse_InvalidJson( void )
 {
     SignalingChannelInfo_t channelInfo;
     SignalingResult_t result;
-    const char * message = "{\"ChannelInfo\": {"; /* Missing Closing Brace. */
-    size_t messageLength = strlen( message );
+    const char * pMessage = "{\"ChannelInfo\": {"; /* Missing Closing Brace. */
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseDescribeSignalingChannelResponse( message,
+    result = Signaling_ParseDescribeSignalingChannelResponse( pMessage,
                                                               messageLength,
                                                               &( channelInfo ) );
 
@@ -333,7 +342,7 @@ void test_signaling_ParseDescribeSignalingChannelResponse_InvalidJson( void )
 
     /* <--------------------------------------------------------------------> */
 
-    const char *message2 =
+    const char * pMessage2 =
     "{"
         "\"ChannelInfo\":"
         "{"
@@ -343,9 +352,9 @@ void test_signaling_ParseDescribeSignalingChannelResponse_InvalidJson( void )
             "}"
         "}"
     "}";
-    size_t messageLength2 = strlen( message2 );
+    size_t messageLength2 = strlen( pMessage2 );
 
-    result = Signaling_ParseDescribeSignalingChannelResponse( message2,
+    result = Signaling_ParseDescribeSignalingChannelResponse( pMessage2,
                                                               messageLength2,
                                                               &( channelInfo ) );
 
@@ -354,10 +363,10 @@ void test_signaling_ParseDescribeSignalingChannelResponse_InvalidJson( void )
 
     /* <--------------------------------------------------------------------> */
 
-    const char *message3 = "{}"; /* Empty Message. */
-    size_t messageLength3 = strlen( message3 );
+    const char * pMessage3 = "{}"; /* Empty Message. */
+    size_t messageLength3 = strlen( pMessage3 );
 
-    result = Signaling_ParseDescribeSignalingChannelResponse( message3,
+    result = Signaling_ParseDescribeSignalingChannelResponse( pMessage3,
                                                               messageLength3,
                                                               &( channelInfo ) );
 
@@ -366,16 +375,16 @@ void test_signaling_ParseDescribeSignalingChannelResponse_InvalidJson( void )
 
     /* <--------------------------------------------------------------------> */
 
-    const char *message4 =
+    const char * pMessage4 =
     "{"
         "\"ChannelInfo\":"
         "{"
             "\"SingleMasterConfiguration\": {}" /* Empty Single Master Configuration. */
         "}"
     "}";
-    size_t messageLength4 = strlen( message4 );
+    size_t messageLength4 = strlen( pMessage4 );
 
-    result = Signaling_ParseDescribeSignalingChannelResponse( message4,
+    result = Signaling_ParseDescribeSignalingChannelResponse( pMessage4,
                                                               messageLength4,
                                                               &( channelInfo ) );
 
@@ -393,7 +402,7 @@ void test_signaling_ParseDescribeSignalingChannelResponse_UnexpectedResponse( vo
 {
     SignalingChannelInfo_t channelInfo;
     SignalingResult_t result;
-    const char * message =
+    const char * pMessage =
     "{"
         "\"ChannelInfo\":"
         "[" /* Unexpected JSON array. */
@@ -402,42 +411,42 @@ void test_signaling_ParseDescribeSignalingChannelResponse_UnexpectedResponse( vo
             "}"
         "]"
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseDescribeSignalingChannelResponse( message,
+    result = Signaling_ParseDescribeSignalingChannelResponse( pMessage,
                                                               messageLength,
                                                               &( channelInfo ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
 
-    /*<----------------------------------------------------------------->*/
+    /* <--------------------------------------------------------------------> */
 
-    const char * message2 =
+    const char * pMessage2 =
     "{"
         "\"Unknown\":" /* Unexpected key. */
         "{"
             "\"ChannelARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123\""
         "}"
     "}";
-    size_t messageLength2 = strlen( message2 );
+    size_t messageLength2 = strlen( pMessage2 );
 
-    result = Signaling_ParseDescribeSignalingChannelResponse( message2,
+    result = Signaling_ParseDescribeSignalingChannelResponse( pMessage2,
                                                               messageLength2,
                                                               &( channelInfo ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
 
-    /*<----------------------------------------------------------------->*/
+    /* <--------------------------------------------------------------------> */
 
-    const char * message3 =
+    const char * pMessage3 =
     "{"
         "\"ChannelXXXX\": {}" /* Unexpected key though the length is same as "ChannelInfo". */
     "}";
-    size_t messageLength3 = strlen( message3 );
+    size_t messageLength3 = strlen( pMessage3 );
 
-    result = Signaling_ParseDescribeSignalingChannelResponse( message3,
+    result = Signaling_ParseDescribeSignalingChannelResponse( pMessage3,
                                                               messageLength3,
                                                               &( channelInfo ) );
 
@@ -450,11 +459,11 @@ void test_signaling_ParseDescribeSignalingChannelResponse_UnexpectedResponse( vo
 /**
  * @brief Validate Signaling Parse Describe Response functionality for Invalid TTL.
  */
-void test_signaling_ParseDescribeSignalingChannelResponse_TttLow( void )
+void test_signaling_ParseDescribeSignalingChannelResponse_TtlLow( void )
 {
     SignalingChannelInfo_t channelInfo;
     SignalingResult_t result;
-    const char *message =
+    const char * pMessage =
     "{"
         "\"ChannelInfo\":"
         "{"
@@ -464,9 +473,9 @@ void test_signaling_ParseDescribeSignalingChannelResponse_TttLow( void )
             "}"
         "}"
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseDescribeSignalingChannelResponse( message,
+    result = Signaling_ParseDescribeSignalingChannelResponse( pMessage,
                                                               messageLength,
                                                               &( channelInfo ) );
 
@@ -483,7 +492,7 @@ void test_signaling_ParseDescribeSignalingChannelResponse_TtlHigh( void )
 {
     SignalingChannelInfo_t channelInfo;
     SignalingResult_t result;
-    const char *message =
+    const char * pMessage =
     "{"
         "\"ChannelInfo\":"
         "{"
@@ -493,9 +502,9 @@ void test_signaling_ParseDescribeSignalingChannelResponse_TtlHigh( void )
             "}"
         "}"
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseDescribeSignalingChannelResponse( message,
+    result = Signaling_ParseDescribeSignalingChannelResponse( pMessage,
                                                               messageLength,
                                                               &( channelInfo ) );
 
@@ -512,7 +521,7 @@ void test_signaling_ParseDescribeSignalingChannelResponse_InvalidTtl( void )
 {
     SignalingChannelInfo_t channelInfo;
     SignalingResult_t result;
-    const char *message =
+    const char * pMessage =
     "{"
         "\"ChannelInfo\":"
         "{"
@@ -522,9 +531,9 @@ void test_signaling_ParseDescribeSignalingChannelResponse_InvalidTtl( void )
             "}"
         "}"
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseDescribeSignalingChannelResponse( message,
+    result = Signaling_ParseDescribeSignalingChannelResponse( pMessage,
                                                               messageLength,
                                                               &( channelInfo ) );
 
@@ -537,20 +546,20 @@ void test_signaling_ParseDescribeSignalingChannelResponse_InvalidTtl( void )
 /**
  * @brief Validate Signaling Parse Describe Response functionality for Invalid Channel Type.
  */
-void test_signaling_ParseDescribeSignalingChannelResponse_InvalidChannel_Type( void )
+void test_signaling_ParseDescribeSignalingChannelResponse_InvalidChannelType( void )
 {
     SignalingChannelInfo_t channelInfo;
     SignalingResult_t result;
-    const char *message =
+    const char * pMessage =
     "{"
         "\"ChannelInfo\":"
         "{"
             "\"ChannelType\": \"INVALID_TYPE\""
         "}"
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseDescribeSignalingChannelResponse( message,
+    result = Signaling_ParseDescribeSignalingChannelResponse( pMessage,
                                                               messageLength,
                                                               &( channelInfo ) );
 
@@ -570,10 +579,10 @@ void test_signaling_ParseDescribeSignalingChannelResponse_ChannelNameTooLong( vo
     char longChannelName[ SIGNALING_CHANNEL_NAME_MAX_LEN + 10 ];
     char message[ 1000 ];
 
-    memset( longChannelName, 'a', sizeof( longChannelName ) - 1 );
+    memset( &( longChannelName[ 0 ] ), 'a', sizeof( longChannelName ) - 1 );
     longChannelName[ sizeof( longChannelName ) - 1 ] = '\0';
 
-    snprintf( message,
+    snprintf( &( message[ 0 ] ),
               sizeof( message ),
               "{"
                     "\"ChannelInfo\":"
@@ -584,7 +593,7 @@ void test_signaling_ParseDescribeSignalingChannelResponse_ChannelNameTooLong( vo
                longChannelName );
     size_t messageLength = strlen( message );
 
-    result = Signaling_ParseDescribeSignalingChannelResponse( message,
+    result = Signaling_ParseDescribeSignalingChannelResponse( &( message[ 0 ] ),
                                                               messageLength,
                                                               &( channelInfo ) );
 
@@ -601,7 +610,7 @@ void test_signaling_ParseDescribeSignalingChannelResponse( void )
 {
     SignalingChannelInfo_t channelInfo;
     SignalingResult_t result;
-    const char *message =
+    const char * pMessage =
     "{"
         "\"ChannelInfo\":"
         "{"
@@ -615,10 +624,10 @@ void test_signaling_ParseDescribeSignalingChannelResponse( void )
             "\"Unknown\": \"200\"" /* Unknown Tag --> Will be skipped. */
         "}"
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
     const char * pExpectedChannelArn = "arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123";
 
-    result = Signaling_ParseDescribeSignalingChannelResponse( message,
+    result = Signaling_ParseDescribeSignalingChannelResponse( pMessage,
                                                               messageLength,
                                                               &( channelInfo ) );
 
@@ -946,8 +955,8 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse_BadParams( void )
 {
     SignalingMediaStorageConfig_t mediaStorageConfig;
     SignalingResult_t result;
-    const char * message = "Valid-Message";
-    size_t messageLength = strlen( message );
+    const char * pMessage = "Valid-Message";
+    size_t messageLength = strlen( pMessage );
 
     result = Signaling_ParseDescribeMediaStorageConfigResponse( NULL,
                                                                 messageLength,
@@ -956,7 +965,7 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    result = Signaling_ParseDescribeMediaStorageConfigResponse( message,
+    result = Signaling_ParseDescribeMediaStorageConfigResponse( pMessage,
                                                                 messageLength,
                                                                 NULL );
 
@@ -973,10 +982,10 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse_InvalidJson( void )
 {
     SignalingMediaStorageConfig_t mediaStorageConfig;
     SignalingResult_t result;
-    const char * message = "{\"MediaStorageConfiguration\": {";  /* Missing closing brace. */
-    size_t messageLength = sizeof( message );
+    const char * pMessage = "{\"MediaStorageConfiguration\": {";  /* Missing closing brace. */
+    size_t messageLength = sizeof( pMessage );
 
-    result = Signaling_ParseDescribeMediaStorageConfigResponse( message,
+    result = Signaling_ParseDescribeMediaStorageConfigResponse( pMessage,
                                                                 messageLength,
                                                                 &( mediaStorageConfig ) );
 
@@ -985,10 +994,10 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse_InvalidJson( void )
 
     /* <--------------------------------------------------------------------> */
 
-    const char * message2 = "{}"; /* Empty JSON. */
-    size_t messageLength2 = strlen( message2 );
+    const char * pMessage2 = "{}"; /* Empty JSON. */
+    size_t messageLength2 = strlen( pMessage2 );
 
-    result = Signaling_ParseDescribeMediaStorageConfigResponse( message2,
+    result = Signaling_ParseDescribeMediaStorageConfigResponse( pMessage2,
                                                                 messageLength2,
                                                                 &( mediaStorageConfig ) );
 
@@ -1005,7 +1014,7 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse_UnexpectedResponse( 
 {
     SignalingMediaStorageConfig_t mediaStorageConfig;
     SignalingResult_t result;
-    const char * message =
+    const char * pMessage =
     "{"
         "\"MediaStorageConfiguration\":"
         "[" /* Unexpected JSON array. */
@@ -1014,18 +1023,19 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse_UnexpectedResponse( 
             "}"
         "]"
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
 
-    result = Signaling_ParseDescribeMediaStorageConfigResponse( message,
-                                                                messageLength, &( mediaStorageConfig ) );
+    result = Signaling_ParseDescribeMediaStorageConfigResponse( pMessage,
+                                                                messageLength,
+                                                                &( mediaStorageConfig ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
 
-    /*<----------------------------------------------------------------->*/
+    /* <--------------------------------------------------------------------> */
 
-    const char * message2 =
+    const char * pMessage2 =
     "{"
         "\"Unknown\":" /* Unknown Key. */
         "{"
@@ -1033,19 +1043,19 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse_UnexpectedResponse( 
             "\"StreamARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:stream/test-stream/1234567890123\""
         "}"
     "}";
-    size_t messageLength2 = strlen( message2 );
+    size_t messageLength2 = strlen( pMessage2 );
 
 
-    result = Signaling_ParseDescribeMediaStorageConfigResponse( message2,
+    result = Signaling_ParseDescribeMediaStorageConfigResponse( pMessage2,
                                                                 messageLength2,
                                                                 &( mediaStorageConfig ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
 
-    /*<----------------------------------------------------------------->*/
+    /* <--------------------------------------------------------------------> */
 
-    const char * message3 =
+    const char * pMessage3 =
     "{"
         "\"PediaStorageConfiguration\":" /* Unknown key even though length of the key is same as "MediaStorageConfiguration". */
         "{"
@@ -1053,9 +1063,9 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse_UnexpectedResponse( 
             "\"StreamARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:stream/test-stream/1234567890123\""
         "}"
     "}";
-    size_t messageLength3 = strlen( message3 );
+    size_t messageLength3 = strlen( pMessage3 );
 
-    result = Signaling_ParseDescribeMediaStorageConfigResponse( message3,
+    result = Signaling_ParseDescribeMediaStorageConfigResponse( pMessage3,
                                                                 messageLength3,
                                                                 &( mediaStorageConfig ) );
 
@@ -1072,7 +1082,7 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse_MissingFields( void 
 {
     SignalingMediaStorageConfig_t mediaStorageConfig;
     SignalingResult_t result;
-    const char *message =
+    const char * pMessage =
     "{"
         "\"MediaStorageConfiguration\":"
         "{"
@@ -1080,9 +1090,9 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse_MissingFields( void 
             /* Missing StreamARN. */
         "}"
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseDescribeMediaStorageConfigResponse( message,
+    result = Signaling_ParseDescribeMediaStorageConfigResponse( pMessage,
                                                                 messageLength,
                                                                 &( mediaStorageConfig ) );
 
@@ -1107,7 +1117,7 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse( void )
 {
     SignalingMediaStorageConfig_t mediaStorageConfig;
     SignalingResult_t result;
-    const char * message =
+    const char * pMessage =
     "{"
         "\"MediaStorageConfiguration\":"
         "{"
@@ -1116,10 +1126,10 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse( void )
             "\"Unknown\": \"Unknown Value\"" /* This will be ignored. */
         "}"
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
     const char * pExpectedStreamArn = "arn:aws:kinesisvideo:us-west-2:123456789012:stream/test-stream/1234567890123";
 
-    result = Signaling_ParseDescribeMediaStorageConfigResponse( message,
+    result = Signaling_ParseDescribeMediaStorageConfigResponse( pMessage,
                                                                 messageLength,
                                                                 &( mediaStorageConfig ) );
 
@@ -1584,9 +1594,9 @@ void test_signaling_ConstructCreateSignalingChannelRequest_WithTagsLeftArrayBrac
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
 
     tags[ 0 ].pName = "Tag1";
-    tags[ 0 ].nameLength = strlen( tags->pName );
+    tags[ 0 ].nameLength = strlen( tags[ 0 ].pName);
     tags[ 0 ].pValue = "Value1";
-    tags[ 0 ].valueLength = strlen( tags->pValue );
+    tags[ 0 ].valueLength = strlen( tags[ 0 ].pValue );
 
     createSignalingChannelRequestInfo.channelName.pChannelName = "Test-Channel";
     createSignalingChannelRequestInfo.channelName.channelNameLength = strlen( createSignalingChannelRequestInfo.channelName.pChannelName );
@@ -1792,8 +1802,8 @@ void test_signaling_ParseCreateSignalingChannelResponse_BadParams( void )
 {
     SignalingChannelArn_t channelArn = { 0 };
     SignalingResult_t result;
-    const char * message = "Valid-Message";
-    size_t messageLength = strlen( message );
+    const char * pMessage = "Valid-Message";
+    size_t messageLength = strlen( pMessage );
 
     result = Signaling_ParseCreateSignalingChannelResponse( NULL,
                                                             messageLength,
@@ -1802,7 +1812,7 @@ void test_signaling_ParseCreateSignalingChannelResponse_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    result = Signaling_ParseCreateSignalingChannelResponse( message,
+    result = Signaling_ParseCreateSignalingChannelResponse( pMessage,
                                                             messageLength,
                                                             NULL );
 
@@ -1819,10 +1829,10 @@ void test_signaling_ParseCreateSignalingChannelResponse_InvalidJson( void )
 {
     SignalingChannelArn_t channelArn = { 0 };
     SignalingResult_t result;
-    const char * message = "{\"ChannelARN\": \"test-arn\"";  /* Missing closing brace. */
-    size_t messageLength = strlen( message );
+    const char * pMessage = "{\"ChannelARN\": \"test-arn\"";  /* Missing closing brace. */
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseCreateSignalingChannelResponse( message,
+    result = Signaling_ParseCreateSignalingChannelResponse( pMessage,
                                                             messageLength,
                                                             &( channelArn ) );
 
@@ -1839,10 +1849,10 @@ void test_signaling_ParseCreateSignalingChannelResponse_UnexpectedResponse( void
 {
     SignalingChannelArn_t channelArn = { 0 };
     SignalingResult_t result;
-    const char * message = "{}";
-    size_t messageLength = strlen( message );
+    const char * pMessage = "{}";
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseCreateSignalingChannelResponse( message,
+    result = Signaling_ParseCreateSignalingChannelResponse( pMessage,
                                                             messageLength,
                                                             &( channelArn ) );
 
@@ -1859,13 +1869,13 @@ void test_signaling_ParseCreateSignalingChannelResponse_UnknownKey( void )
 {
     SignalingChannelArn_t channelArn = { 0 };
     SignalingResult_t result;
-    const char * message =
+    const char * pMessage =
     "{"
         "\"Unknown\": \"arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123\""
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseCreateSignalingChannelResponse( message,
+    result = Signaling_ParseCreateSignalingChannelResponse( pMessage,
                                                             messageLength,
                                                             &( channelArn ) );
 
@@ -1882,14 +1892,14 @@ void test_signaling_ParseCreateSignalingChannelResponse( void )
 {
     SignalingChannelArn_t channelArn = { 0 };
     SignalingResult_t result;
-    const char *message =
+    const char * pMessage =
     "{"
         "\"ChannelARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123\""
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
     const char * pExpectedChannelArn = "arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123";
 
-    result = Signaling_ParseCreateSignalingChannelResponse( message,
+    result = Signaling_ParseCreateSignalingChannelResponse( pMessage,
                                                             messageLength,
                                                             &( channelArn ) );
 
@@ -1913,7 +1923,7 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_BadParams( void 
     GetSignalingChannelEndpointRequestInfo_t getSignalingChannelEndPointRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
     SignalingResult_t result;
-    const char * channelArn = "arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123";
+    const char * pChannelArn = "arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123";
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( NULL,
                                                                     &( getSignalingChannelEndPointRequestInfo ),
@@ -1979,7 +1989,7 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_BadParams( void 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn = channelArn;
+    getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn = pChannelArn;
     getSignalingChannelEndPointRequestInfo.channelArn.channelArnLength = strlen( getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn );
     getSignalingChannelEndPointRequestInfo.role = SIGNALING_ROLE_NONE;
 
@@ -2345,8 +2355,8 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse_BadParams( void )
 {
     SignalingChannelEndpoints_t endpoints;
     SignalingResult_t result;
-    const char * message = "Valid-Message";
-    size_t messageLength = strlen( message );
+    const char * pMessage = "Valid-Message";
+    size_t messageLength = strlen( pMessage );
 
     result = Signaling_ParseGetSignalingChannelEndpointResponse( NULL,
                                                                  messageLength,
@@ -2355,7 +2365,7 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    result = Signaling_ParseGetSignalingChannelEndpointResponse( message,
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( pMessage,
                                                                  messageLength,
                                                                  NULL );
 
@@ -2372,10 +2382,10 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse_InvalidJson( void )
 {
     SignalingChannelEndpoints_t endpoints;
     SignalingResult_t result;
-    const char * message = "{\"ResourceEndpointList\": [";  /* Missing closing bracket. */
-    size_t messageLength = strlen( message );
+    const char * pMessage = "{\"ResourceEndpointList\": [";  /* Missing closing bracket. */
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseGetSignalingChannelEndpointResponse( message,
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( pMessage,
                                                                  messageLength,
                                                                  &( endpoints ) );
 
@@ -2384,10 +2394,10 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse_InvalidJson( void )
 
     /* <--------------------------------------------------------------------> */
 
-    const char * message2 = "{}"; /* Empty JSON. */
-    size_t messageLength2 = strlen( message2 );
+    const char * pMessage2 = "{}"; /* Empty JSON. */
+    size_t messageLength2 = strlen( pMessage2 );
 
-    result = Signaling_ParseGetSignalingChannelEndpointResponse( message2,
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( pMessage2,
                                                                  messageLength2,
                                                                  &( endpoints ) );
 
@@ -2405,7 +2415,7 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse_UnexpectedResponse(
 {
     SignalingChannelEndpoints_t endpoints;
     SignalingResult_t result;
-    const char * message =
+    const char * pMessage =
     "{"
         "\"ResourceEndpointList\":"
         "{" /* Not JSON Array Type. */
@@ -2414,17 +2424,18 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse_UnexpectedResponse(
             "{\"Protocol\": \"WEBRTC\", \"ResourceEndpoint\": \"webrtc://example.com\"}"
         "}"
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseGetSignalingChannelEndpointResponse( message,
-                                                                 messageLength, &( endpoints ) );
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( pMessage,
+                                                                 messageLength,
+                                                                 &( endpoints ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
 
-    /*<----------------------------------------------------------------->*/
+    /* <--------------------------------------------------------------------> */
 
-    const char * message2 =
+    const char * pMessage2 =
     "{"
         "\"Unknown\":" /* Unknown key. */
         "["
@@ -2433,21 +2444,21 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse_UnexpectedResponse(
             "{\"Protocol\": \"WEBRTC\", \"ResourceEndpoint\": \"webrtc://example.com\"}"
         "]"
     "}";
-    size_t messageLength2 = strlen( message2 );
+    size_t messageLength2 = strlen( pMessage2 );
 
-    result = Signaling_ParseGetSignalingChannelEndpointResponse( message2,
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( pMessage2,
                                                                  messageLength2,
                                                                  &( endpoints ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
 
-    /*<----------------------------------------------------------------->*/
+    /* <--------------------------------------------------------------------> */
 
-    const char * message3 = "{\"ResourceEndpointBist\": []}"; /* Unknown key. */
-    size_t messageLength3 = strlen( message3 );
+    const char * pMessage3 = "{\"ResourceEndpointBist\": []}"; /* Unknown key. */
+    size_t messageLength3 = strlen( pMessage3 );
 
-    result = Signaling_ParseGetSignalingChannelEndpointResponse( message3,
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( pMessage3,
                                                                  messageLength3,
                                                                  &( endpoints ) );
 
@@ -2464,7 +2475,7 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse_InvalidProtocol( vo
 {
     SignalingChannelEndpoints_t endpoints;
     SignalingResult_t result;
-    const char * message =
+    const char * pMessage =
     "{"
         "\"ResourceEndpointList\":"
         "["
@@ -2474,18 +2485,18 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse_InvalidProtocol( vo
             "}"
         "]"
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseGetSignalingChannelEndpointResponse( message,
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( pMessage,
                                                                  messageLength,
                                                                  &( endpoints ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_PROTOCOL,
                        result );
 
-    /*<----------------------------------------------------------------->*/
+    /* <--------------------------------------------------------------------> */
 
-    const char * message2 =
+    const char * pMessage2 =
     "{"
         "\"ResourceEndpointList\":"
         "["
@@ -2495,18 +2506,18 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse_InvalidProtocol( vo
             "}"
         "]"
     "}";
-    size_t messageLength2 = strlen( message2 );
+    size_t messageLength2 = strlen( pMessage2 );
 
-    result = Signaling_ParseGetSignalingChannelEndpointResponse( message2,
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( pMessage2,
                                                                  messageLength2,
                                                                  &( endpoints ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_PROTOCOL,
                        result );
 
-    /*<----------------------------------------------------------------->*/
+    /* <--------------------------------------------------------------------> */
 
-    const char * message3 =
+    const char * pMessage3 =
     "{"
         "\"ResourceEndpointList\":"
         "["
@@ -2516,18 +2527,18 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse_InvalidProtocol( vo
             "}"
         "]"
     "}";
-    size_t messageLength3 = strlen( message3 );
+    size_t messageLength3 = strlen( pMessage3 );
 
-    result = Signaling_ParseGetSignalingChannelEndpointResponse( message3,
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( pMessage3,
                                                                  messageLength3,
                                                                  &( endpoints ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_PROTOCOL,
                        result );
 
-    /*<----------------------------------------------------------------->*/
+    /* <--------------------------------------------------------------------> */
 
-    const char * message4 =
+    const char * pMessage4 =
     "{"
         "\"ResourceEndpointList\":"
         "["
@@ -2537,9 +2548,9 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse_InvalidProtocol( vo
             "}"
         "]"
     "}";
-    size_t messageLength4 = strlen( message4 );
+    size_t messageLength4 = strlen( pMessage4 );
 
-    result = Signaling_ParseGetSignalingChannelEndpointResponse( message4,
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( pMessage4,
                                                                  messageLength4,
                                                                  &( endpoints ) );
 
@@ -2556,7 +2567,7 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse( void )
 {
     SignalingChannelEndpoints_t endpoints;
     SignalingResult_t result;
-    const char *message =
+    const char * pMessage =
     "{"
         "\"ResourceEndpointList\":"
         "["
@@ -2567,30 +2578,30 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse( void )
             "{\"Protocol\": \"WEBRTC\", \"Unknown\": \"webrtc://example.com\"}"               /* Unknown Tag is ignored. */
         "]"
     "}";
-    size_t messageLength = strlen( message );
-    const char * expectedWssURL = "wss://example.com";
-    const char * expectedHttpsURL = "https://example.com";
-    const char * expectedWebrtcURL = "webrtc://example.com";
+    size_t messageLength = strlen( pMessage );
+    const char * pExpectedWssURL = "wss://example.com";
+    const char * pExpectedHttpsURL = "https://example.com";
+    const char * pExpectedWebrtcURL = "webrtc://example.com";
 
-    result = Signaling_ParseGetSignalingChannelEndpointResponse( message,
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( pMessage,
                                                                  messageLength,
                                                                  &( endpoints ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL( strlen( expectedWssURL ),
+    TEST_ASSERT_EQUAL( strlen( pExpectedWssURL ),
                        endpoints.wssEndpoint.endpointLength );
-    TEST_ASSERT_EQUAL_STRING_LEN( expectedWssURL,
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedWssURL,
                                   endpoints.wssEndpoint.pEndpoint,
                                    endpoints.wssEndpoint.endpointLength );
-    TEST_ASSERT_EQUAL( strlen( expectedHttpsURL ),
+    TEST_ASSERT_EQUAL( strlen( pExpectedHttpsURL ),
                        endpoints.httpsEndpoint.endpointLength );
-    TEST_ASSERT_EQUAL_STRING_LEN( expectedHttpsURL,
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedHttpsURL,
                                   endpoints.httpsEndpoint.pEndpoint,
                                   endpoints.httpsEndpoint.endpointLength );
-    TEST_ASSERT_EQUAL( strlen( expectedWebrtcURL ),
+    TEST_ASSERT_EQUAL( strlen( pExpectedWebrtcURL ),
                        endpoints.webrtcEndpoint.endpointLength );
-    TEST_ASSERT_EQUAL_STRING_LEN( expectedWebrtcURL,
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedWebrtcURL,
                                   endpoints.webrtcEndpoint.pEndpoint,
                                   endpoints.webrtcEndpoint.endpointLength );
 }
@@ -2604,7 +2615,7 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse_SmallCaps( void )
 {
     SignalingChannelEndpoints_t endpoints;
     SignalingResult_t result;
-    const char *message =
+    const char * pMessage =
     "{"
         "\"ResourceEndpointList\":"
         "["
@@ -2613,30 +2624,30 @@ void test_signaling_ParseGetSignalingChannelEndpointResponse_SmallCaps( void )
             "{\"Protocol\": \"webrtc\", \"ResourceEndpoint\": \"webrtc://example.com\"}"
         "]"
     "}";
-    size_t messageLength = strlen( message );
-    const char * expectedWssURL = "wss://example.com";
-    const char * expectedHttpsURL = "https://example.com";
-    const char * expectedWebrtcURL = "webrtc://example.com";
+    size_t messageLength = strlen( pMessage );
+    const char * pExpectedWssURL = "wss://example.com";
+    const char * pExpectedHttpsURL = "https://example.com";
+    const char * pExpectedWebrtcURL = "webrtc://example.com";
 
-    result = Signaling_ParseGetSignalingChannelEndpointResponse( message,
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( pMessage,
                                                                  messageLength,
                                                                  &( endpoints ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL( strlen( expectedWssURL ),
+    TEST_ASSERT_EQUAL( strlen( pExpectedWssURL ),
                        endpoints.wssEndpoint.endpointLength );
-    TEST_ASSERT_EQUAL_STRING_LEN( expectedWssURL,
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedWssURL,
                                   endpoints.wssEndpoint.pEndpoint,
                                   endpoints.wssEndpoint.endpointLength );
-    TEST_ASSERT_EQUAL( strlen( expectedHttpsURL ),
+    TEST_ASSERT_EQUAL( strlen( pExpectedHttpsURL ),
                        endpoints.httpsEndpoint.endpointLength );
-    TEST_ASSERT_EQUAL_STRING_LEN( expectedHttpsURL,
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedHttpsURL,
                                   endpoints.httpsEndpoint.pEndpoint,
                                   endpoints.httpsEndpoint.endpointLength );
-    TEST_ASSERT_EQUAL( strlen( expectedWebrtcURL ),
+    TEST_ASSERT_EQUAL( strlen( pExpectedWebrtcURL ),
                        endpoints.webrtcEndpoint.endpointLength );
-    TEST_ASSERT_EQUAL_STRING_LEN( expectedWebrtcURL,
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedWebrtcURL,
                                   endpoints.webrtcEndpoint.pEndpoint,
                                   endpoints.webrtcEndpoint.endpointLength );
 }
@@ -2660,7 +2671,7 @@ void test_signaling_ConstructGetIceServerConfigRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     endpoint.pEndpoint = NULL;
 
@@ -2671,7 +2682,7 @@ void test_signaling_ConstructGetIceServerConfigRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     endpoint.pEndpoint = "https://example.com";
 
@@ -2682,7 +2693,7 @@ void test_signaling_ConstructGetIceServerConfigRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     result = Signaling_ConstructGetIceServerConfigRequest( &( endpoint ),
                                                            NULL,
@@ -2691,7 +2702,7 @@ void test_signaling_ConstructGetIceServerConfigRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     requestBuffer.pUrl = NULL;
 
@@ -2702,7 +2713,7 @@ void test_signaling_ConstructGetIceServerConfigRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     requestBuffer.pUrl = "https://kinesisvideo.cn-east-1.amazonaws.com.cn/describeSignalingChannel";
     requestBuffer.urlLength = strlen( requestBuffer.pUrl );
@@ -2715,7 +2726,7 @@ void test_signaling_ConstructGetIceServerConfigRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     requestBuffer.pBody = "{\"ChannelName\":\"Test-Channel-China\"}";
     requestBuffer.bodyLength = strlen( requestBuffer.pBody );
@@ -2861,8 +2872,8 @@ void test_signaling_ParseGetIceServerConfigResponse_BadParams( void )
     SignalingIceServer_t iceServers;
     size_t numIceServers;
     SignalingResult_t result;
-    const char * message = "Valid-Message";
-    size_t messageLength = strlen( message );
+    const char * pMessage = "Valid-Message";
+    size_t messageLength = strlen( pMessage );
 
     result = Signaling_ParseGetIceServerConfigResponse( NULL,
                                                         messageLength,
@@ -2872,7 +2883,7 @@ void test_signaling_ParseGetIceServerConfigResponse_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    result = Signaling_ParseGetIceServerConfigResponse( message,
+    result = Signaling_ParseGetIceServerConfigResponse( pMessage,
                                                         messageLength,
                                                         NULL,
                                                         &( numIceServers ) );
@@ -2880,7 +2891,7 @@ void test_signaling_ParseGetIceServerConfigResponse_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    result = Signaling_ParseGetIceServerConfigResponse( message,
+    result = Signaling_ParseGetIceServerConfigResponse( pMessage,
                                                         messageLength,
                                                         &( iceServers ),
                                                         NULL );
@@ -2899,11 +2910,11 @@ void test_signaling_ParseGetIceServerConfigResponse_InvalidJson( void )
     SignalingIceServer_t iceServers[ 1 ];
     size_t numIceServers = 1;
     SignalingResult_t result;
-    const char * message = "{\"IceServerList\": ["; /* Missing closing bracket. */
-    size_t messageLength = strlen( message );
+    const char * pMessage = "{\"IceServerList\": ["; /* Missing closing bracket. */
+    size_t messageLength = strlen( pMessage );
 
 
-    result = Signaling_ParseGetIceServerConfigResponse( message,
+    result = Signaling_ParseGetIceServerConfigResponse( pMessage,
                                                         messageLength,
                                                         &( iceServers[ 0 ] ),
                                                         &( numIceServers ) );
@@ -2911,12 +2922,12 @@ void test_signaling_ParseGetIceServerConfigResponse_InvalidJson( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
                        result );
 
-    /*<----------------------------------------------------------------->*/
+    /* <--------------------------------------------------------------------> */
 
-    const char * message2 = "{}"; /* Empty JSON. */
-    size_t messageLength2 = strlen( message2 );
+    const char * pMessage2 = "{}"; /* Empty JSON. */
+    size_t messageLength2 = strlen( pMessage2 );
 
-    result = Signaling_ParseGetIceServerConfigResponse( message2,
+    result = Signaling_ParseGetIceServerConfigResponse( pMessage2,
                                                         messageLength2,
                                                         &( iceServers[ 0 ] ),
                                                         &( numIceServers ) );
@@ -2935,7 +2946,7 @@ void test_signaling_ParseGetIceServerConfigResponse_UnexpectedResponse( void )
     SignalingIceServer_t iceServers[ 1 ];
     size_t numIceServers = 1;
     SignalingResult_t result;
-    const char * message =
+    const char * pMessage =
     "{"
         "\"IceServerList\":"
         "{" /* Not JSON Array Type. */
@@ -2947,9 +2958,9 @@ void test_signaling_ParseGetIceServerConfigResponse_UnexpectedResponse( void )
             "}"
         "}"
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseGetIceServerConfigResponse( message,
+    result = Signaling_ParseGetIceServerConfigResponse( pMessage,
                                                         messageLength,
                                                         &( iceServers[ 0 ] ),
                                                         &( numIceServers ) );
@@ -2957,9 +2968,9 @@ void test_signaling_ParseGetIceServerConfigResponse_UnexpectedResponse( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
 
-    /*<----------------------------------------------------------------->*/
+    /* <--------------------------------------------------------------------> */
 
-    const char * message2 =
+    const char * pMessage2 =
     "{"
         "\"Unknown\":" /* Unknown key. */
         "["
@@ -2971,9 +2982,9 @@ void test_signaling_ParseGetIceServerConfigResponse_UnexpectedResponse( void )
             "}"
         "]"
     "}";
-    size_t messageLength2 = strlen( message2 );
+    size_t messageLength2 = strlen( pMessage2 );
 
-    result = Signaling_ParseGetIceServerConfigResponse( message2,
+    result = Signaling_ParseGetIceServerConfigResponse( pMessage2,
                                                         messageLength2,
                                                         &( iceServers[ 0 ] ),
                                                         &( numIceServers ) );
@@ -2981,12 +2992,12 @@ void test_signaling_ParseGetIceServerConfigResponse_UnexpectedResponse( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
 
-    /*<----------------------------------------------------------------->*/
+    /* <--------------------------------------------------------------------> */
 
-    const char * message3 = "{\"UnexpectedKey\": []}"; /* Unknown Key Though the length of "IceServerList" == "UnexpectedKey". */
-    size_t messageLength3 = strlen( message3 );
+    const char * pMessage3 = "{\"UnexpectedKey\": []}"; /* Unknown Key Though the length of "IceServerList" == "UnexpectedKey". */
+    size_t messageLength3 = strlen( pMessage3 );
 
-    result = Signaling_ParseGetIceServerConfigResponse( message3,
+    result = Signaling_ParseGetIceServerConfigResponse( pMessage3,
                                                         messageLength3,
                                                         &( iceServers[ 0 ] ),
                                                         &( numIceServers ) );
@@ -3005,7 +3016,7 @@ void test_signaling_ParseGetIceServerConfigResponse_InvalidTtl( void )
     SignalingIceServer_t iceServers[ 1 ];
     size_t numIceServers = 1;
     SignalingResult_t result;
-    const char * message =
+    const char * pMessage =
     "{"
         "\"IceServerList\":"
         "["
@@ -3017,9 +3028,9 @@ void test_signaling_ParseGetIceServerConfigResponse_InvalidTtl( void )
             "}"
         "]"
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseGetIceServerConfigResponse( message,
+    result = Signaling_ParseGetIceServerConfigResponse( pMessage,
                                                         messageLength,
                                                         &( iceServers[ 0 ] ),
                                                         &( numIceServers ) );
@@ -3038,7 +3049,7 @@ void test_signaling_ParseGetIceServerConfigResponse_LowTtl( void )
     SignalingIceServer_t iceServers[ 1 ];
     size_t numIceServers = 1;
     SignalingResult_t result;
-    const char * message =
+    const char * pMessage =
     "{"
         "\"IceServerList\":"
         "["
@@ -3050,9 +3061,9 @@ void test_signaling_ParseGetIceServerConfigResponse_LowTtl( void )
             "}"
         "]"
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseGetIceServerConfigResponse( message,
+    result = Signaling_ParseGetIceServerConfigResponse( pMessage,
                                                         messageLength,
                                                         &( iceServers[ 0 ] ),
                                                         &( numIceServers ) );
@@ -3071,7 +3082,7 @@ void test_signaling_ParseGetIceServerConfigResponse_HighTtl( void )
     SignalingIceServer_t iceServers[ 1 ];
     size_t numIceServers = 1;
     SignalingResult_t result;
-    const char * message =
+    const char * pMessage =
     "{"
         "\"IceServerList\":"
         "["
@@ -3083,9 +3094,9 @@ void test_signaling_ParseGetIceServerConfigResponse_HighTtl( void )
             "}"
         "]"
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseGetIceServerConfigResponse( message,
+    result = Signaling_ParseGetIceServerConfigResponse( pMessage,
                                                         messageLength,
                                                         &( iceServers[ 0 ] ),
                                                         &( numIceServers ) );
@@ -3104,7 +3115,7 @@ void test_signaling_ParseGetIceServerConfigResponse( void )
     SignalingIceServer_t iceServers[ 1 ];
     size_t numIceServers = 1;
     SignalingResult_t result;
-    const char * message =
+    const char * pMessage =
     "{"
         "\"IceServerList\":"
         "["
@@ -3117,9 +3128,9 @@ void test_signaling_ParseGetIceServerConfigResponse( void )
             "}"
         "]"
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseGetIceServerConfigResponse( message,
+    result = Signaling_ParseGetIceServerConfigResponse( pMessage,
                                                         messageLength,
                                                         &( iceServers[ 0 ] ),
                                                         &( numIceServers ) );
@@ -3159,16 +3170,16 @@ void test_signaling_ParseGetIceServerConfigResponse_Empty( void )
     SignalingIceServer_t iceServers[ 1 ];
     size_t numIceServers = 1;
     SignalingResult_t result;
-    const char * message =
+    const char * pMessage =
     "{"
         "\"IceServerList\":"
         "["
             /* Empty Buffer will be ignored. */
         "]"
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseGetIceServerConfigResponse( message,
+    result = Signaling_ParseGetIceServerConfigResponse( pMessage,
                                                         messageLength,
                                                         &( iceServers[ 0 ] ),
                                                         &( numIceServers ) );
@@ -3198,7 +3209,7 @@ void test_signaling_ConstructJoinStorageSessionRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     webrtcEndpoint.pEndpoint = NULL;
 
@@ -3209,7 +3220,7 @@ void test_signaling_ConstructJoinStorageSessionRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     webrtcEndpoint.pEndpoint = "webrtc://example.com";
     webrtcEndpoint.endpointLength = strlen( webrtcEndpoint.pEndpoint );
@@ -3221,7 +3232,7 @@ void test_signaling_ConstructJoinStorageSessionRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
 
 
@@ -3232,7 +3243,7 @@ void test_signaling_ConstructJoinStorageSessionRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     requestBuffer.pUrl = NULL;
 
@@ -3243,7 +3254,7 @@ void test_signaling_ConstructJoinStorageSessionRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     requestBuffer.pUrl = "https://kinesisvideo.cn-east-1.amazonaws.com.cn/describeSignalingChannel";
     requestBuffer.urlLength = strlen( requestBuffer.pUrl );
@@ -3256,7 +3267,7 @@ void test_signaling_ConstructJoinStorageSessionRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     requestBuffer.pBody = "{\"ChannelName\":\"Test-Channel-China\"}";
     requestBuffer.bodyLength = strlen( requestBuffer.pBody );
@@ -3462,7 +3473,7 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     awsRegion.pAwsRegion = NULL;
 
@@ -3473,7 +3484,7 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -3485,7 +3496,7 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
                                                                NULL,
@@ -3494,7 +3505,7 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     requestBuffer.pUrl = NULL;
 
@@ -3505,7 +3516,7 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     requestBuffer.pUrl = "https://kinesisvideo.cn-east-1.amazonaws.com.cn/describeSignalingChannel";
     requestBuffer.urlLength = strlen( requestBuffer.pUrl );
@@ -3518,7 +3529,7 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     requestBuffer.pBody = "{\"ChannelName\":\"Test-Channel-China\"}";
     requestBuffer.bodyLength = strlen( requestBuffer.pBody );
@@ -3531,7 +3542,7 @@ void test_signaling_ConstructDeleteSignalingChannelRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     deleteSignalingChannelRequestInfo.channelArn.pChannelArn = "arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123";
     deleteSignalingChannelRequestInfo.channelArn.channelArnLength = strlen( deleteSignalingChannelRequestInfo.channelArn.pChannelArn );
@@ -3787,7 +3798,7 @@ void test_signaling_ConstructConnectWssEndpointRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     wssEndpoint.pEndpoint = NULL;
 
@@ -3798,7 +3809,7 @@ void test_signaling_ConstructConnectWssEndpointRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     wssEndpoint.pEndpoint = "wss://example.com";
     wssEndpoint.endpointLength = strlen( wssEndpoint.pEndpoint );
@@ -3810,9 +3821,7 @@ void test_signaling_ConstructConnectWssEndpointRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
-
-
+    /* <--------------------------------------------------------------------> */
 
     result = Signaling_ConstructConnectWssEndpointRequest( &( wssEndpoint ),
                                                            NULL,
@@ -3821,7 +3830,7 @@ void test_signaling_ConstructConnectWssEndpointRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     requestBuffer.pUrl = NULL;
 
@@ -3832,7 +3841,7 @@ void test_signaling_ConstructConnectWssEndpointRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     requestBuffer.pUrl = "https://kinesisvideo.cn-east-1.amazonaws.com.cn/describeSignalingChannel";
     requestBuffer.urlLength = strlen( requestBuffer.pUrl );
@@ -3845,7 +3854,7 @@ void test_signaling_ConstructConnectWssEndpointRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     connectWssEndpointRequestInfo.channelArn.pChannelArn = "arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123";
     connectWssEndpointRequestInfo.channelArn.channelArnLength = strlen( connectWssEndpointRequestInfo.channelArn.pChannelArn );
@@ -3858,7 +3867,7 @@ void test_signaling_ConstructConnectWssEndpointRequest_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     connectWssEndpointRequestInfo.role = SIGNALING_ROLE_VIEWER;
     connectWssEndpointRequestInfo.pClientId = NULL;
@@ -3952,7 +3961,7 @@ void test_signaling_ConstructConnectWssEndpointRequest_Viewer( void )
                        requestBuffer.urlLength );
     TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
                                   requestBuffer.pUrl,
-                                   requestBuffer.urlLength );
+                                  requestBuffer.urlLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -4009,7 +4018,7 @@ void test_signaling_ConstructWssMessage_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     result = Signaling_ConstructWssMessage( &( wssSendMessage ),
                                             NULL,
@@ -4018,7 +4027,7 @@ void test_signaling_ConstructWssMessage_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     wssSendMessage.pBase64EncodedMessage = NULL;
 
@@ -4029,7 +4038,7 @@ void test_signaling_ConstructWssMessage_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
     wssSendMessage.pBase64EncodedMessage = "TestMessage";
     wssSendMessage.base64EncodedMessageLength = strlen( wssSendMessage.pBase64EncodedMessage );
@@ -4343,9 +4352,9 @@ void test_signaling_ParseWssRecvMessage_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    /*      <------------------------------------------------------------------------------------------>      */
+    /* <--------------------------------------------------------------------> */
 
-    result = Signaling_ParseWssRecvMessage( message,
+    result = Signaling_ParseWssRecvMessage( &( message[ 0 ] ),
                                             messageLength,
                                             NULL );
 
@@ -4362,15 +4371,15 @@ void test_signaling_ParseWssRecvMessage_SdpOffer( void )
 {
     SignalingResult_t result;
     WssRecvMessage_t wssRecvMessage = { 0 };
-    const char * message =
+    const char * pMessage =
     "{"
         "\"senderClientId\":\"sender123\","
         "\"messageType\":\"SDP_OFFER\","
         "\"messagePayload\":\"base64encodedpayload\""
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseWssRecvMessage( message,
+    result = Signaling_ParseWssRecvMessage( pMessage,
                                             messageLength,
                                             &( wssRecvMessage ) );
 
@@ -4399,15 +4408,15 @@ void test_signaling_ParseWssRecvMessage_SdpAnswer( void )
 {
     SignalingResult_t result;
     WssRecvMessage_t wssRecvMessage = { 0 };
-    const char *message =
+    const char * pMessage =
     "{"
         "\"senderClientId\":\"sender123\","
         "\"messageType\":\"SDP_ANSWER\","
         "\"messagePayload\":\"base64encodedpayload\""
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseWssRecvMessage( message,
+    result = Signaling_ParseWssRecvMessage( pMessage,
                                             messageLength,
                                             &( wssRecvMessage ) );
 
@@ -4436,15 +4445,15 @@ void test_signaling_ParseWssRecvMessage_IceCandidate( void )
 {
     SignalingResult_t result;
     WssRecvMessage_t wssRecvMessage = { 0 };
-    const char *message =
+    const char * pMessage =
     "{"
         "\"senderClientId\":\"sender123\","
         "\"messageType\":\"ICE_CANDIDATE\","
         "\"messagePayload\":\"base64encodedpayload\""
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseWssRecvMessage( message,
+    result = Signaling_ParseWssRecvMessage( pMessage,
                                             messageLength,
                                             &( wssRecvMessage ) );
 
@@ -4473,15 +4482,15 @@ void test_signaling_ParseWssRecvMessage_GoAway( void )
 {
     SignalingResult_t result;
     WssRecvMessage_t wssRecvMessage = { 0 };
-    const char *message =
+    const char * pMessage =
     "{"
         "\"senderClientId\":\"sender123\","
         "\"messageType\":\"GO_AWAY\","
         "\"messagePayload\":\"base64encodedpayload\""
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseWssRecvMessage( message,
+    result = Signaling_ParseWssRecvMessage( pMessage,
                                             messageLength,
                                             &( wssRecvMessage ) );
 
@@ -4510,15 +4519,15 @@ void test_signaling_ParseWssRecvMessage_ExcludeNullTerminator( void )
 {
     SignalingResult_t result;
     WssRecvMessage_t wssRecvMessage = { 0 };
-    const char *message =
+    const char * pMessage =
     "{"
         "\"senderClientId\":\"sender123\","
         "\"messageType\":\"RECONNECT_ICE_SERVER\","
         "\"messagePayload\":\"base64encodedpayload\""
     "}";
-    size_t messageLength = strlen( message ) + 1 ; /* Length including null terminator. */
+    size_t messageLength = strlen( pMessage ) + 1 ; /* Length including null terminator. */
 
-    result = Signaling_ParseWssRecvMessage( message,
+    result = Signaling_ParseWssRecvMessage( pMessage,
                                             messageLength,
                                             &( wssRecvMessage ) );
 
@@ -4547,16 +4556,17 @@ void test_signaling_ParseWssRecvMessage_ReconnectIceServer( void )
 {
     SignalingResult_t result;
     WssRecvMessage_t wssRecvMessage = { 0 };
-    const char *message =
+    const char * pMessage =
     "{"
         "\"senderClientId\":\"sender123\","
         "\"messageType\":\"RECONNECT_ICE_SERVER\","
         "\"messagePayload\":\"base64encodedpayload\""
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseWssRecvMessage( message,
-                                            messageLength, &( wssRecvMessage ) );
+    result = Signaling_ParseWssRecvMessage( pMessage,
+                                            messageLength,
+                                            &( wssRecvMessage ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
@@ -4583,7 +4593,7 @@ void test_signaling_ParseWssRecvMessage_StatusResponse( void )
 {
     SignalingResult_t result;
     WssRecvMessage_t wssRecvMessage = { 0 };
-    const char *message =
+    const char * pMessage =
     "{"
         "\"messageType\":\"STATUS_RESPONSE\","
         "\"statusResponse\":"
@@ -4595,9 +4605,9 @@ void test_signaling_ParseWssRecvMessage_StatusResponse( void )
             "\"Unknown\":\"value\"" /* Unknown Tags are ignored. */
         "}"
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseWssRecvMessage( message,
+    result = Signaling_ParseWssRecvMessage( pMessage,
                                             messageLength,
                                             &( wssRecvMessage ) );
 
@@ -4636,12 +4646,12 @@ void test_signaling_ParseWssRecvMessage_InvalidJson( void )
 {
     SignalingResult_t result;
     WssRecvMessage_t wssRecvMessage = { 0 };
-    const char * message =
+    const char * pMessage =
     "{"
         "\"senderClientId\":\"sender123\",";  /* Missing closing brace. */
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseWssRecvMessage( message,
+    result = Signaling_ParseWssRecvMessage( pMessage,
                                             messageLength,
                                             &( wssRecvMessage ) );
 
@@ -4658,16 +4668,16 @@ void test_signaling_ParseWssRecvMessage_UnknownMessageType( void )
 {
     SignalingResult_t result;
     WssRecvMessage_t wssRecvMessage = { 0 };
-    const char *message  =
+    const char * pMessage =
     "{"
         "\"senderClientId\":\"sender123\","
         "\"messageType\":\"UNKNOWN_TYPE\"," /* Unknown Message Type. */
         "\"messagePayload\":\"base64encodedpayload\","
         "\"Unknown\":\"unknown-value\"" /* This Unknown Tag is ignored. */
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseWssRecvMessage( message,
+    result = Signaling_ParseWssRecvMessage( pMessage,
                                             messageLength,
                                             &( wssRecvMessage ) );
 
@@ -4686,14 +4696,14 @@ void test_signaling_ParseWssRecvMessage_UnexpectedStatusResponse( void )
 {
     SignalingResult_t result;
     WssRecvMessage_t wssRecvMessage = { 0 };
-    const char *message  =
+    const char * pMessage  =
     "{"
         "\"messageType\":\"STATUS_RESPONSE\","
         "\"statusResponse\":\"invalid\"" /* Invalid Status Response. */
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseWssRecvMessage( message,
+    result = Signaling_ParseWssRecvMessage( pMessage,
                                             messageLength,
                                             &( wssRecvMessage ) );
 
@@ -4710,7 +4720,7 @@ void test_signaling_ParseWssRecvMessage_InvalidStatusResponse( void )
 {
     SignalingResult_t result;
     WssRecvMessage_t wssRecvMessage = { 0 };
-    const char *message  =
+    const char * pMessage =
     "{"
         "\"messageType\":\"STATUS_RESPONSE\","
         "\"statusResponse\":"
@@ -4718,9 +4728,9 @@ void test_signaling_ParseWssRecvMessage_InvalidStatusResponse( void )
             /* Empty Status Response. */
         "}"
     "}";
-    size_t messageLength = strlen( message );
+    size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseWssRecvMessage( message,
+    result = Signaling_ParseWssRecvMessage( pMessage,
                                             messageLength,
                                             &( wssRecvMessage ) );
 
@@ -4737,10 +4747,10 @@ void test_signaling_ParseWssRecvMessage_Empty( void )
 {
     SignalingResult_t result;
     WssRecvMessage_t wssRecvMessage = { 0 };
-    const char *message  = "";
+    const char * pMessage = "";
     size_t messageLength = 0;
 
-    result = Signaling_ParseWssRecvMessage( message,
+    result = Signaling_ParseWssRecvMessage( pMessage,
                                             messageLength,
                                             &( wssRecvMessage ) );
 

--- a/test/unit-test/signaling_api/signaling_api_utest.c
+++ b/test/unit-test/signaling_api/signaling_api_utest.c
@@ -299,7 +299,7 @@ void test_signaling_ParseDescribeSignalingChannelResponse_BadParams( void )
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    result = Signaling_ParseDescribeSignalingChannelResponse( message ,
+    result = Signaling_ParseDescribeSignalingChannelResponse( message,
                                                               messageLength, NULL );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
@@ -338,6 +338,33 @@ void test_signaling_ParseDescribeSignalingChannelResponse_InvalidJson( void )
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
                        result );
+
+    /* <--------------------------------------------------------------------> */
+
+    const char *message3 = "{"
+    "}";                                                                   /* Empty Message */
+    size_t messageLength3 = strlen( message3 );
+
+    result = Signaling_ParseDescribeSignalingChannelResponse( message3,
+                                                              messageLength3, &( channelInfo ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
+                       result );
+
+    /* <--------------------------------------------------------------------> */
+
+    const char *message4 = "{"
+        "\"ChannelInfo\": {"
+            "\"SingleMasterConfiguration\": {}"                             /* Empty Single Master Configuration */
+        "}"
+    "}";                                                              
+    size_t messageLength4 = strlen( message4 );
+
+    result = Signaling_ParseDescribeSignalingChannelResponse( message4,
+                                                              messageLength4, &( channelInfo ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
+                       result );
 }
 
 /*-----------------------------------------------------------*/
@@ -348,13 +375,43 @@ void test_signaling_ParseDescribeSignalingChannelResponse_InvalidJson( void )
  */
 void test_signaling_ParseDescribeSignalingChannelResponse_UnexpectedResponse( void )
 {
-    const char * message = "{\"UnexpectedKey\": {}}";            /* The Key is not known */
+    const char * message = "{"
+        "\"ChannelInfo\": ["                                                                    /* Opening Bracket Not JSON Object Type */
+            "{\"ChannelARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123\"}"
+        "]"                                                                                     /* Closing Bracket Not JSON Object Type */  
+    "}";
     size_t messageLength = strlen( message );
     SignalingChannelInfo_t channelInfo;
     SignalingResult_t result;
 
     result = Signaling_ParseDescribeSignalingChannelResponse( message,
                                                               messageLength, &( channelInfo ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
+                       result );
+
+    /*<----------------------------------------------------------------->*/
+
+    const char * message2 = "{"
+        "\"Unkown\": {"                           
+            "\"ChannelARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123\""
+        "}"                                        
+    "}";
+    size_t messageLength2 = strlen( message2 );
+
+    result = Signaling_ParseDescribeSignalingChannelResponse( message2,
+                                                              messageLength2, &( channelInfo ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
+                       result );
+
+    /*<----------------------------------------------------------------->*/
+
+    const char * message3 = "{\"ChannelXXXX\": {}}";            /* The Key is not known though the length is same as "ChannelInfo". */
+    size_t messageLength3 = strlen( message3 );
+
+    result = Signaling_ParseDescribeSignalingChannelResponse( message3,
+                                                              messageLength3, &( channelInfo ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
@@ -394,7 +451,30 @@ void test_signaling_ParseDescribeSignalingChannelResponse_InvalidTTL_High( void 
     SignalingResult_t result;
     const char *message =  "{"
         "\"ChannelInfo\": {"
-            "\"SingleMasterConfiguration\": {\"MessageTtlSeconds\": 999999999}"         /* The Valid Range for message TTL is [ 5-120 ] Seconds  */
+            "\"SingleMasterConfiguration\": {\"MessageTtlSeconds\": 999}"         /* The Valid Range for message TTL is [ 5-120 ] Seconds  */
+        "}"
+    "}";
+    size_t messageLength = strlen( message );
+
+    result = Signaling_ParseDescribeSignalingChannelResponse( message,
+                                                              messageLength, &( channelInfo ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_TTL,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Describe Response functionality for Invalid TTL.
+ */
+void test_signaling_ParseDescribeSignalingChannelResponse_InvalidTTL_Buffer( void )
+{
+    SignalingChannelInfo_t channelInfo;
+    SignalingResult_t result;
+    const char *message =  "{"
+        "\"ChannelInfo\": {"
+            "\"SingleMasterConfiguration\": {\"MessageTtlSeconds\": 9999999}"         /* The Valid Range for message TTL is < SIGNALING_CHANNEL_TTL_SECONDS_BUFFER_MAX ( 5 ), Here is 7  */
         "}"
     "}";
     size_t messageLength = strlen( message );
@@ -440,6 +520,7 @@ void test_signaling_ParseDescribeSignalingChannelResponse_InvalidChannel_Name( v
     SignalingResult_t result;
 
     char longChannelName[ SIGNALING_CHANNEL_NAME_MAX_LEN + 10 ];
+
     memset( longChannelName, 'a', sizeof( longChannelName ) - 1 );
     longChannelName[ sizeof( longChannelName ) - 1 ] = '\0';
     char message[ 1000 ];
@@ -474,11 +555,12 @@ void test_signaling_ParseDescribeSignalingChannelResponse( void )
             "\"ChannelType\": \"SINGLE_MASTER\","
             "\"CreationTime\": \"2023-05-01T12:00:00Z\","
             "\"SingleMasterConfiguration\": {\"MessageTtlSeconds\": 60},"
-            "\"Version\": \"1\""
+            "\"Version\": \"1\","
+            "\"Unkown\": \"200\""                       /* Unkown Tag --> Will be skipped */
         "}"
     "}";
     size_t messageLength = strlen( message );
-    const char* pExpectedChannelArn = "arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123";
+    const char * pExpectedChannelArn = "arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123";
 
     result = Signaling_ParseDescribeSignalingChannelResponse( message,
                                                               messageLength, &( channelInfo ) );
@@ -487,7 +569,7 @@ void test_signaling_ParseDescribeSignalingChannelResponse( void )
                        result );
     TEST_ASSERT_EQUAL_STRING_LEN( pExpectedChannelArn,
                                   channelInfo.channelArn.pChannelArn,
-                                  strlen(pExpectedChannelArn));
+                                  strlen( pExpectedChannelArn ) );
     TEST_ASSERT_EQUAL_STRING_LEN( "test-channel",
                                   channelInfo.channelName.pChannelName,
                                   channelInfo.channelName.channelNameLength );
@@ -766,7 +848,7 @@ void test_signaling_ConstructDescribeMediaStorageConfigRequest_BodyOutOfMemory( 
 void test_signaling_ParseDescribeMediaStorageConfigResponse_BadParams( void )
 {
     const char * message = "Valid-Message";
-    size_t messageLength = strlen(message);
+    size_t messageLength = strlen( message );
     SignalingMediaStorageConfig_t mediaStorageConfig;
     SignalingResult_t result;
 
@@ -800,6 +882,17 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse_InvalidJson( void )
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
                        result );
+
+    /* <--------------------------------------------------------------------> */
+    const char * message2 = "{"                                  /* Empty JSON */
+                            "}";
+    size_t messageLength2 = strlen( message2 );
+
+    result = Signaling_ParseDescribeMediaStorageConfigResponse( message2,
+                                                                messageLength2, &( mediaStorageConfig ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
+                       result );
 }
 
 /*-----------------------------------------------------------*/
@@ -809,13 +902,55 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse_InvalidJson( void )
  */
 void test_signaling_ParseDescribeMediaStorageConfigResponse_UnexpectedResponse( void )
 {
-    const char * message = "{\"UnexpectedKey\": {}}";        /* Unkown Key */
-    size_t messageLength = strlen( message );
     SignalingMediaStorageConfig_t mediaStorageConfig;
     SignalingResult_t result;
+    const char * message =  \
+        "{"
+            "\"PediaStorageConfiguration\":"               
+           "["                                                                              /* Opening Bracket Not JSON Object Type */
+                "{\"StreamARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:stream/test-stream/1234567890123\"}"
+            "]"                                                                             /* Closing Bracket Not JSON Object Type */
+        "}";
+    size_t messageLength = strlen( message );
+
 
     result = Signaling_ParseDescribeMediaStorageConfigResponse( message,
                                                                 messageLength, &( mediaStorageConfig ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
+                       result );
+    /*<----------------------------------------------------------------->*/
+
+    const char * message2 =  \
+        "{"
+            "\"Unkown\":"                    /* Unkown Key */      
+           "{"             
+                "\"Status\": \"ENABLED\","
+                "\"StreamARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:stream/test-stream/1234567890123\""
+            "}"          
+        "}";
+    size_t messageLength2 = strlen( message2 );
+
+
+    result = Signaling_ParseDescribeMediaStorageConfigResponse( message2,
+                                                                messageLength2, &( mediaStorageConfig ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
+                       result );
+    /*<----------------------------------------------------------------->*/
+
+    const char * message3 =  \
+        "{"
+            "\"PediaStorageConfiguration\":"                /* Key is not known, even though length of the key is same as "MediaStorageConfiguration". */
+           "{"
+                "\"Status\": \"ENABLED\","
+                "\"StreamARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:stream/test-stream/1234567890123\""
+            "}"
+        "}";
+    size_t messageLength3 = strlen( message3 );
+
+    result = Signaling_ParseDescribeMediaStorageConfigResponse( message3,
+                                                                messageLength3, &( mediaStorageConfig ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
@@ -856,7 +991,7 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse( void )
 {
     SignalingMediaStorageConfig_t mediaStorageConfig;
     SignalingResult_t result;
-    const char *message  =  \
+    const char * message =  \
         "{"
             "\"MediaStorageConfiguration\":"
            "{"
@@ -867,6 +1002,7 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse( void )
         "}";
     size_t messageLength = strlen( message );
     const char * pExpectedStreamArn = "arn:aws:kinesisvideo:us-west-2:123456789012:stream/test-stream/1234567890123";
+
     result = Signaling_ParseDescribeMediaStorageConfigResponse( message,
                                                                 messageLength, &( mediaStorageConfig ) );
 
@@ -877,7 +1013,7 @@ void test_signaling_ParseDescribeMediaStorageConfigResponse( void )
                        mediaStorageConfig.streamArnLength );
     TEST_ASSERT_EQUAL_STRING_LEN( pExpectedStreamArn,
                                   mediaStorageConfig.pStreamArn,
-                                  strlen(pExpectedStreamArn) );
+                                  strlen( pExpectedStreamArn ) );
 }
 
 /*-----------------------------------------------------------*/
@@ -962,6 +1098,114 @@ void test_signaling_ConstructCreateSignalingChannelRequest_BadParams( void )
 /**
  * @brief Validate Signaling Construct Channel Request functionality.
  */
+void test_signaling_ConstructCreateSignalingChannelRequest_Url_OutofMemory( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 20 ];       /* URL Buffer small */
+    char bodyBuffer[ 500 ];
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    createSignalingChannelRequestInfo.channelName.pChannelName = "Test-Channel";
+    createSignalingChannelRequestInfo.channelName.channelNameLength = strlen( createSignalingChannelRequestInfo.channelName.pChannelName );
+    createSignalingChannelRequestInfo.channelType = SIGNALING_TYPE_CHANNEL_SINGLE_MASTER;
+    createSignalingChannelRequestInfo.messageTtlSeconds = 60;
+    createSignalingChannelRequestInfo.numTags = 0;
+    createSignalingChannelRequestInfo.pTags = NULL;
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
+                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Channel Request functionality.
+ */
+void test_signaling_ConstructCreateSignalingChannelRequest_Body_OutofMemory( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 100 ];     /* Body Buffer Small */
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    createSignalingChannelRequestInfo.channelName.pChannelName = "Test-Channel";
+    createSignalingChannelRequestInfo.channelName.channelNameLength = strlen( createSignalingChannelRequestInfo.channelName.pChannelName );
+    createSignalingChannelRequestInfo.channelType = SIGNALING_TYPE_CHANNEL_SINGLE_MASTER;
+    createSignalingChannelRequestInfo.messageTtlSeconds = 60;
+    createSignalingChannelRequestInfo.numTags = 0;
+    createSignalingChannelRequestInfo.pTags = NULL;
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
+                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Channel Request functionality.
+ */
+void test_signaling_ConstructCreateSignalingChannelRequest_Body_RightBracket_OutofMemory( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 113 ];                 /* Body Buffer in-capable of adding the "}" in the Body */
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    createSignalingChannelRequestInfo.channelName.pChannelName = "Test-Channel";
+    createSignalingChannelRequestInfo.channelName.channelNameLength = strlen( createSignalingChannelRequestInfo.channelName.pChannelName );
+    createSignalingChannelRequestInfo.channelType = SIGNALING_TYPE_CHANNEL_SINGLE_MASTER;
+    createSignalingChannelRequestInfo.messageTtlSeconds = 60;
+    createSignalingChannelRequestInfo.numTags = 0;
+    createSignalingChannelRequestInfo.pTags = NULL;
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
+                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Channel Request functionality.
+ */
 void test_signaling_ConstructCreateSignalingChannelRequest( void )
 {
     SignalingAwsRegion_t awsRegion = { 0 };
@@ -1006,7 +1250,59 @@ void test_signaling_ConstructCreateSignalingChannelRequest( void )
     TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
                        requestBuffer.bodyLength );
     TEST_ASSERT_EQUAL_STRING( pExpectedBody,
-                              requestBuffer.pBody );                   
+                              requestBuffer.pBody );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Channel Request functionality.
+ */
+void test_signaling_ConstructCreateSignalingChannelRequest_Unkown_ChannelType( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 500 ];
+    SignalingResult_t result;
+    const char * pExpectedUrl = "https://kinesisvideo.us-east-1.amazonaws.com/createSignalingChannel";
+    const char * pExpectedBody = "{"
+                                    "\"ChannelName\":\"Test-Channel\","
+                                    "\"ChannelType\":\"UNKOWN\","
+                                    "\"SingleMasterConfiguration\":{"
+                                        "\"MessageTtlSeconds\":60"
+                                    "}"
+                                  "}";
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    createSignalingChannelRequestInfo.channelName.pChannelName = "Test-Channel";
+    createSignalingChannelRequestInfo.channelName.channelNameLength = strlen( createSignalingChannelRequestInfo.channelName.pChannelName );
+    createSignalingChannelRequestInfo.channelType = SIGNALING_TYPE_CHANNEL_UNKNOWN;
+    createSignalingChannelRequestInfo.messageTtlSeconds = 60;
+    createSignalingChannelRequestInfo.numTags = 0;
+    createSignalingChannelRequestInfo.pTags = NULL;
+
+    requestBuffer.pUrl = &( urlBuffer[ 0 ] );
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = &( bodyBuffer[ 0 ] );
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
+                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
+                       requestBuffer.urlLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
+                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
+                       requestBuffer.bodyLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
+                              requestBuffer.pBody );
 }
 
 /*-----------------------------------------------------------*/
@@ -1118,11 +1414,147 @@ void test_signaling_ConstructCreateSignalingChannelRequest_ChinaRegion( void )
 /**
  * @brief Validate Signaling Construct Channel Request functionality.
  */
-void test_signaling_ConstructCreateSignalingChannelRequest_WithTags( void )
+void test_signaling_ConstructCreateSignalingChannelRequest_WithTags_LeftArrayBracket_OutofMemory( void )
 {
     SignalingAwsRegion_t awsRegion = { 0 };
     CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
     SignalingTag_t tags[ 1 ] = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 121 ];         /* Buffer in-capable of adding "[" in the body */
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    tags->pName = "Tag1";
+    tags->nameLength = strlen( tags->pName );
+    tags->pValue = "Value1";
+    tags->valueLength = strlen( tags->pValue );
+
+    createSignalingChannelRequestInfo.channelName.pChannelName = "Test-Channel";
+    createSignalingChannelRequestInfo.channelName.channelNameLength = strlen( createSignalingChannelRequestInfo.channelName.pChannelName );
+    createSignalingChannelRequestInfo.channelType = SIGNALING_TYPE_CHANNEL_SINGLE_MASTER;
+    createSignalingChannelRequestInfo.messageTtlSeconds = 60;
+    createSignalingChannelRequestInfo.numTags = 1;
+    createSignalingChannelRequestInfo.pTags = tags;
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
+                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Channel Request functionality.
+ */
+void test_signaling_ConstructCreateSignalingChannelRequest_WithTags_OutofMemory( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
+    SignalingTag_t tags[ 2 ] = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 170 ];         /* Buffer in-capable of adding Tags in the body */
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    tags[ 0 ].pName = "Tag1";
+    tags[ 0 ].nameLength = strlen( tags[ 0 ].pName );
+    tags[ 0 ].pValue = "Value1";
+    tags[ 0 ].valueLength = strlen( tags[ 0 ].pValue );
+
+    tags[ 1 ].pName = "Tag2";
+    tags[ 1 ].nameLength = strlen( tags[ 1 ].pName );
+    tags[ 1 ].pValue = "Value2";
+    tags[ 1 ].valueLength = strlen( tags[ 1 ].pValue );
+
+    createSignalingChannelRequestInfo.channelName.pChannelName = "Test-Channel";
+    createSignalingChannelRequestInfo.channelName.channelNameLength = strlen( createSignalingChannelRequestInfo.channelName.pChannelName );
+    createSignalingChannelRequestInfo.channelType = SIGNALING_TYPE_CHANNEL_SINGLE_MASTER;
+    createSignalingChannelRequestInfo.messageTtlSeconds = 60;
+    createSignalingChannelRequestInfo.numTags = 2;
+    createSignalingChannelRequestInfo.pTags = tags;
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
+                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Channel Request functionality.
+ */
+void test_signaling_ConstructCreateSignalingChannelRequest_WithTags_RightArrayBracket_OutofMemory( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
+    SignalingTag_t tags[ 2 ] = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 185 ];         /* Buffer in-capable of adding "]" in the body */
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    tags[ 0 ].pName = "Tag1";
+    tags[ 0 ].nameLength = strlen( tags[ 0 ].pName );
+    tags[ 0 ].pValue = "Value1";
+    tags[ 0 ].valueLength = strlen( tags[ 0 ].pValue );
+
+    tags[ 1 ].pName = "Tag2";
+    tags[ 1 ].nameLength = strlen( tags[ 1 ].pName );
+    tags[ 1 ].pValue = "Value2";
+    tags[ 1 ].valueLength = strlen( tags[ 1 ].pValue );
+
+    createSignalingChannelRequestInfo.channelName.pChannelName = "Test-Channel";
+    createSignalingChannelRequestInfo.channelName.channelNameLength = strlen( createSignalingChannelRequestInfo.channelName.pChannelName );
+    createSignalingChannelRequestInfo.channelType = SIGNALING_TYPE_CHANNEL_SINGLE_MASTER;
+    createSignalingChannelRequestInfo.messageTtlSeconds = 60;
+    createSignalingChannelRequestInfo.numTags = 2;
+    createSignalingChannelRequestInfo.pTags = tags;
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
+                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Channel Request functionality.
+ */
+void test_signaling_ConstructCreateSignalingChannelRequest_WithTags( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
+    SignalingTag_t tags[ 2 ] = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
     char urlBuffer[ 200 ];
     char bodyBuffer[ 500 ];
@@ -1138,6 +1570,10 @@ void test_signaling_ConstructCreateSignalingChannelRequest_WithTags( void )
                                         "{"
                                             "\"Key\":\"Tag1\","
                                             "\"Value\":\"Value1\""
+                                        "},"
+                                        "{"
+                                            "\"Key\":\"Tag2\","
+                                            "\"Value\":\"Value2\""
                                         "}"
                                     "]"
                                   "}";
@@ -1145,16 +1581,21 @@ void test_signaling_ConstructCreateSignalingChannelRequest_WithTags( void )
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
 
-    tags->pName = "Tag1";
-    tags->nameLength = strlen( tags->pName );
-    tags->pValue = "Value1";
-    tags->valueLength = strlen( tags->pValue );
+    tags[ 0 ].pName = "Tag1";
+    tags[ 0 ].nameLength = strlen( tags[ 0 ].pName );
+    tags[ 0 ].pValue = "Value1";
+    tags[ 0 ].valueLength = strlen( tags[ 0 ].pValue );
+
+    tags[ 1 ].pName = "Tag2";
+    tags[ 1 ].nameLength = strlen( tags[ 1 ].pName );
+    tags[ 1 ].pValue = "Value2";
+    tags[ 1 ].valueLength = strlen( tags[ 1 ].pValue );
 
     createSignalingChannelRequestInfo.channelName.pChannelName = "Test-Channel";
     createSignalingChannelRequestInfo.channelName.channelNameLength = strlen( createSignalingChannelRequestInfo.channelName.pChannelName );
     createSignalingChannelRequestInfo.channelType = SIGNALING_TYPE_CHANNEL_SINGLE_MASTER;
     createSignalingChannelRequestInfo.messageTtlSeconds = 60;
-    createSignalingChannelRequestInfo.numTags = 1;
+    createSignalingChannelRequestInfo.numTags = 2;
     createSignalingChannelRequestInfo.pTags = tags;
 
     requestBuffer.pUrl = &( urlBuffer[ 0 ] );
@@ -1245,6 +1686,29 @@ void test_signaling_ParseCreateSignalingChannelResponse_UnexpectedResponse( void
 /**
  * @brief Validate Signaling Parse Create Signaling Channel Response functionality.
  */
+void test_signaling_ParseCreateSignalingChannelResponse_Unkown( void )
+{
+    const char * message = "{"
+        "\"Unkown\": \"arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123\""        /* Unkown is ignored */
+    "}";
+    size_t messageLength = strlen( message );
+    SignalingChannelArn_t channelArn = { 0 };
+    SignalingResult_t result;
+
+    result = Signaling_ParseCreateSignalingChannelResponse( message,
+                                                            messageLength, &( channelArn ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( 0, channelArn.pChannelArn );
+    TEST_ASSERT_EQUAL( 0, channelArn.channelArnLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Create Signaling Channel Response functionality.
+ */
 void test_signaling_ParseCreateSignalingChannelResponse( void )
 {
     SignalingChannelArn_t channelArn = { 0 };
@@ -1260,11 +1724,10 @@ void test_signaling_ParseCreateSignalingChannelResponse( void )
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL( strlen(pExpectedChannelArn), channelArn.channelArnLength );
+    TEST_ASSERT_EQUAL( strlen( pExpectedChannelArn ), channelArn.channelArnLength );
     TEST_ASSERT_EQUAL_STRING_LEN( pExpectedChannelArn,
                                   channelArn.pChannelArn,
                                   channelArn.channelArnLength );
-    
 }
 
 /*-----------------------------------------------------------*/
@@ -1277,7 +1740,7 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_BadParams( void 
     SignalingAwsRegion_t awsRegion = { 0 };
     GetSignalingChannelEndpointRequestInfo_t getSignalingChannelEndPointRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
-    char channelArn[] = "arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123";
+    const char * channelArn = "arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123";
     SignalingResult_t result;
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( NULL,
@@ -1287,6 +1750,7 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_BadParams( void 
                        result );
 
     awsRegion.pAwsRegion = NULL;
+
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
                                                                     &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
 
@@ -1295,11 +1759,6 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_BadParams( void 
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
-    result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
-                                                                    NULL, &( requestBuffer ) );
-
-    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
-                       result );
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
                                                                     &( getSignalingChannelEndPointRequestInfo ), NULL );
@@ -1307,7 +1766,14 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_BadParams( void 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
+    result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
+                                                                    NULL, &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
     requestBuffer.pUrl = NULL;
+
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
                                                                     &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
 
@@ -1317,6 +1783,7 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_BadParams( void 
     requestBuffer.pUrl = "https://kinesisvideo.cn-east-1.amazonaws.com.cn/describeSignalingChannel";
     requestBuffer.urlLength = strlen( requestBuffer.pUrl );
     requestBuffer.pBody = NULL;
+
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
                                                                     &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
 
@@ -1326,15 +1793,17 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_BadParams( void 
     requestBuffer.pBody = "{\"ChannelName\":\"Test-Channel\"}";
     requestBuffer.bodyLength = strlen( requestBuffer.pBody );
     getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn = NULL;
+
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
                                                                     &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn = &( channelArn[ 0 ] );
+    getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn = channelArn;
     getSignalingChannelEndPointRequestInfo.channelArn.channelArnLength = strlen( getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn );
     getSignalingChannelEndPointRequestInfo.role = SIGNALING_ROLE_NONE;
+
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
                                                                     &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
 
@@ -1347,7 +1816,75 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_BadParams( void 
 /**
  * @brief Validate Signaling Construct Get Channel Endpoint Request functionality .
  */
-void test_signaling_ConstructGetSignalingChannelEndpointRequest( void )
+void test_signaling_ConstructGetSignalingChannelEndpointRequest_URL_OutofMemory( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    GetSignalingChannelEndpointRequestInfo_t getSignalingChannelEndPointRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 72 ];           /* Small URL Buffer */
+    char bodyBuffer[ 500 ];
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn = "arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123";
+    getSignalingChannelEndPointRequestInfo.channelArn.channelArnLength = strlen( getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn );
+    getSignalingChannelEndPointRequestInfo.role = SIGNALING_ROLE_VIEWER;
+    getSignalingChannelEndPointRequestInfo.protocols = SIGNALING_PROTOCOL_WEBRTC | SIGNALING_PROTOCOL_WEBSOCKET_SECURE;
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
+                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Get Channel Endpoint Request functionality .
+ */
+void test_signaling_ConstructGetSignalingChannelEndpointRequest_Body_OutofMemory( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    GetSignalingChannelEndpointRequestInfo_t getSignalingChannelEndPointRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 184 ];         /* Small Body Buffer */
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn = "arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123";
+    getSignalingChannelEndPointRequestInfo.channelArn.channelArnLength = strlen( getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn );
+    getSignalingChannelEndPointRequestInfo.role = SIGNALING_ROLE_MASTER;
+    getSignalingChannelEndPointRequestInfo.protocols = SIGNALING_PROTOCOL_HTTPS | SIGNALING_PROTOCOL_WEBSOCKET_SECURE;
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
+                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Get Channel Endpoint Request functionality .
+ */
+void test_signaling_ConstructGetSignalingChannelEndpointRequest_HTTP( void )
 {
     SignalingAwsRegion_t awsRegion = { 0 };
     GetSignalingChannelEndpointRequestInfo_t getSignalingChannelEndPointRequestInfo = { 0 };
@@ -1390,6 +1927,2293 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest( void )
                        requestBuffer.bodyLength );
     TEST_ASSERT_EQUAL_STRING( pExpectedBody,
                               requestBuffer.pBody );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Get Channel Endpoint Request functionality .
+ */
+void test_signaling_ConstructGetSignalingChannelEndpointRequest_ChinaRegion( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    GetSignalingChannelEndpointRequestInfo_t getSignalingChannelEndPointRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 500 ];
+    SignalingResult_t result;
+    const char * pExpectedUrl = "https://kinesisvideo.cn-east-1.amazonaws.com.cn/getSignalingChannelEndpoint";
+    const char * pExpectedBody = "{"
+                                    "\"ChannelARN\":\"arn:aws-cn:kinesisvideo:cn-east-1:123456789012:channel/test-channel/1234567890123\","
+                                    "\"SingleMasterChannelEndpointConfiguration\":{"
+                                        "\"Protocols\":[\"WSS\",\"HTTPS\"],"
+                                        "\"Role\":\"VIEWER\""
+                                    "}"
+                                  "}";
+
+    awsRegion.pAwsRegion = "cn-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn = "arn:aws-cn:kinesisvideo:cn-east-1:123456789012:channel/test-channel/1234567890123";
+    getSignalingChannelEndPointRequestInfo.channelArn.channelArnLength = strlen( getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn );
+    getSignalingChannelEndPointRequestInfo.role = SIGNALING_ROLE_VIEWER;
+    getSignalingChannelEndPointRequestInfo.protocols = SIGNALING_PROTOCOL_HTTPS | SIGNALING_PROTOCOL_WEBSOCKET_SECURE;
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
+                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
+                       requestBuffer.urlLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
+                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
+                       requestBuffer.bodyLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
+                              requestBuffer.pBody );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Get Channel Endpoint Request functionality .
+ */
+void test_signaling_ConstructGetSignalingChannelEndpointRequest_SmallLengthRegion( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    GetSignalingChannelEndpointRequestInfo_t getSignalingChannelEndPointRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 500 ];
+    SignalingResult_t result;
+    const char * pExpectedUrl = "https://kinesisvideo.ca.amazonaws.com/getSignalingChannelEndpoint";
+    const char * pExpectedBody = "{"
+                                    "\"ChannelARN\":\"arn:aws:kinesisvideo:ca:123456789012:channel/test-channel/1234567890123\","
+                                    "\"SingleMasterChannelEndpointConfiguration\":{"
+                                        "\"Protocols\":[\"WSS\",\"HTTPS\"],"
+                                        "\"Role\":\"MASTER\""
+                                    "}"
+                                  "}";
+
+    awsRegion.pAwsRegion = "ca";                /* The Region Length is < 3 */
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn = "arn:aws:kinesisvideo:ca:123456789012:channel/test-channel/1234567890123";
+    getSignalingChannelEndPointRequestInfo.channelArn.channelArnLength = strlen( getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn );
+    getSignalingChannelEndPointRequestInfo.role = SIGNALING_ROLE_MASTER;
+    getSignalingChannelEndPointRequestInfo.protocols = SIGNALING_PROTOCOL_WEBSOCKET_SECURE | SIGNALING_PROTOCOL_HTTPS;
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
+                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
+                       requestBuffer.urlLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
+                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
+                       requestBuffer.bodyLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
+                              requestBuffer.pBody );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Get Channel Endpoint Request functionality .
+ */
+void test_signaling_ConstructGetSignalingChannelEndpointRequest_WebSockets_Or_WebRTC( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    GetSignalingChannelEndpointRequestInfo_t getSignalingChannelEndPointRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 500 ];
+    SignalingResult_t result;
+    const char * pExpectedUrl = "https://kinesisvideo.us-east-1.amazonaws.com/getSignalingChannelEndpoint";
+    const char * pExpectedBody = "{"
+                                    "\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\","
+                                    "\"SingleMasterChannelEndpointConfiguration\":{"
+                                        "\"Protocols\":[\"WSS\",\"WEBRTC\"],"
+                                        "\"Role\":\"MASTER\""
+                                    "}"
+                                  "}";
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn = "arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123";
+    getSignalingChannelEndPointRequestInfo.channelArn.channelArnLength = strlen( getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn );
+    getSignalingChannelEndPointRequestInfo.role = SIGNALING_ROLE_MASTER;
+    getSignalingChannelEndPointRequestInfo.protocols = SIGNALING_PROTOCOL_WEBRTC | SIGNALING_PROTOCOL_WEBSOCKET_SECURE;
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
+                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
+                       requestBuffer.urlLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
+                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
+                       requestBuffer.bodyLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
+                              requestBuffer.pBody );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Get Channel Endpoint Request functionality .
+ */
+void test_signaling_ConstructGetSignalingChannelEndpointRequest_WebRTC( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    GetSignalingChannelEndpointRequestInfo_t getSignalingChannelEndPointRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 500 ];
+    SignalingResult_t result;
+    const char * pExpectedUrl = "https://kinesisvideo.us-east-1.amazonaws.com/getSignalingChannelEndpoint";
+    const char * pExpectedBody = "{"
+                                    "\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\","
+                                    "\"SingleMasterChannelEndpointConfiguration\":{"
+                                        "\"Protocols\":[\"WEBRTC\"],"
+                                        "\"Role\":\"MASTER\""
+                                    "}"
+                                  "}";
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn = "arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123";
+    getSignalingChannelEndPointRequestInfo.channelArn.channelArnLength = strlen( getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn );
+    getSignalingChannelEndPointRequestInfo.role = SIGNALING_ROLE_MASTER;
+    getSignalingChannelEndPointRequestInfo.protocols = SIGNALING_PROTOCOL_WEBRTC;
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
+                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
+                       requestBuffer.urlLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
+                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
+                       requestBuffer.bodyLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
+                              requestBuffer.pBody );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Get Endpoint Response fail functionality for Bad Parameters.
+ */
+void test_signaling_ParseGetSignalingChannelEndpointResponse_BadParams( void )
+{
+    const char * message = "Valid-Message";
+    size_t messageLength = strlen( message );
+    SignalingChannelEndpoints_t endpoints;
+    SignalingResult_t result;
+
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( NULL,
+                                                                 messageLength, &( endpoints ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( message,
+                                                                 messageLength, NULL );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Get Endpoint Response functionality for Invalid JSON.
+ */
+void test_signaling_ParseGetSignalingChannelEndpointResponse_InvalidJson( void )
+{
+    const char * message = "{\"ResourceEndpointList\": [";  /* Missing closing bracket */
+    size_t messageLength = strlen( message );
+    SignalingChannelEndpoints_t endpoints;
+    SignalingResult_t result;
+
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( message,
+                                                                 messageLength, &( endpoints ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
+                       result );
+
+    /* <--------------------------------------------------------------------> */
+
+    const char * message2 = "{"                                  /* Empty JSON */
+                            "}";
+    size_t messageLength2 = strlen( message2 );
+
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( message2,
+                                                                 messageLength2, &( endpoints ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+
+/**
+ * @brief Validate Signaling Parse Get Endpoint Response functionality for Unexpected Response.
+ */
+void test_signaling_ParseGetSignalingChannelEndpointResponse_UnexpectedResponse( void )
+{
+    SignalingChannelEndpoints_t endpoints;
+    SignalingResult_t result;
+    const char * message = "{"
+        "\"ResourceEndpointList\": {"                                                   /* Opening Bracket Not JSON Array Type */
+            "{\"Protocol\": \"WSS\", \"ResourceEndpoint\": \"wss://example.com\"},"
+            "{\"Protocol\": \"HTTPS\", \"ResourceEndpoint\": \"https://example.com\"},"
+            "{\"Protocol\": \"WEBRTC\", \"ResourceEndpoint\": \"webrtc://example.com\"}"
+        "}"                                                                              /* Closing Bracket not Not JSON Array Type */
+    "}";
+    size_t messageLength = strlen( message );
+
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( message,
+                                                                 messageLength, &( endpoints ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
+                       result );
+
+    /*<----------------------------------------------------------------->*/
+
+    const char * message2 = "{"
+        "\"Unkown\": ["                                                                      /* Unkown Key */      
+            "{\"Protocol\": \"WSS\", \"ResourceEndpoint\": \"wss://example.com\"},"
+            "{\"Protocol\": \"HTTPS\", \"ResourceEndpoint\": \"https://example.com\"},"
+            "{\"Protocol\": \"WEBRTC\", \"ResourceEndpoint\": \"webrtc://example.com\"}"
+        "]"                                             
+    "}";
+    size_t messageLength2 = strlen( message2 );
+
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( message2,
+                                                                 messageLength2, &( endpoints ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
+                       result );
+
+    /*<----------------------------------------------------------------->*/
+
+    const char * message3 = "{\"ResourceEndpointBist\": []}";                                 /* The Key is not known */
+    size_t messageLength3 = strlen( message3 );
+
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( message3,
+                                                                 messageLength3, &( endpoints ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Get Endpoint Response functionality for Unexpected Response.
+ */
+void test_signaling_ParseGetSignalingChannelEndpointResponse_InvalidProtocol( void )
+{
+    SignalingChannelEndpoints_t endpoints;
+    SignalingResult_t result;
+    const char * message = "{"
+        "\"ResourceEndpointList\": ["
+            "{\"Protocol\": \"INVALID\", \"ResourceEndpoint\": \"invalid://example.com\"}"
+        "]"
+    "}";
+    size_t messageLength = strlen( message );
+
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( message,
+                                                                 messageLength, &( endpoints ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_PROTOCOL,
+                       result );
+
+    /*<----------------------------------------------------------------->*/
+
+    const char * message2 = "{"
+        "\"ResourceEndpointList\": ["
+            "{\"Protocol\": \"ABS\", \"ResourceEndpoint\": \"abs://example.com\"}"          /* Protocol length == 3  but protocol != WSS */
+        "]"
+    "}";
+    size_t messageLength2 = strlen( message2 );
+
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( message2,
+                                                                 messageLength2, &( endpoints ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_PROTOCOL,
+                       result );
+
+    /*<----------------------------------------------------------------->*/
+
+    const char * message3 = "{"
+        "\"ResourceEndpointList\": ["
+            "{\"Protocol\": \"HTTPA\", \"ResourceEndpoint\": \"httpa://example.com\"}"          /* Protocol length == 5  but protocol != HTTPS */
+        "]"
+    "}";
+    size_t messageLength3 = strlen( message3 );
+
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( message3,
+                                                                 messageLength3, &( endpoints ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_PROTOCOL,
+                       result );
+
+    /*<----------------------------------------------------------------->*/
+
+    const char * message4 = "{"
+        "\"ResourceEndpointList\": ["
+            "{\"Protocol\": \"WEBRTA\", \"ResourceEndpoint\": \"webrta://example.com\"}"          /* Protocol length == 6  but protocol != WEBRTC */
+        "]"
+    "}";
+    size_t messageLength4 = strlen( message4 );
+
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( message4,
+                                                                 messageLength4, &( endpoints ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_PROTOCOL,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Get Endpoint Response functionality.
+ */
+void test_signaling_ParseGetSignalingChannelEndpointResponse( void )
+{
+    SignalingChannelEndpoints_t endpoints;
+    SignalingResult_t result;
+    const char *message = "{"
+        "\"ResourceEndpointList\": ["
+            "{\"Protocol\": \"WSS\", \"ResourceEndpoint\": \"wss://example.com\"},"
+            "{\"Protocol\": \"HTTPS\", \"ResourceEndpoint\": \"https://example.com\"},"
+            "{\"Protocol\": \"WEBRTC\", \"ResourceEndpoint\": \"webrtc://example.com\"},"
+            "{\"Unkown\": \"WEBRTC\", \"ResourceEndpoint\": \"webrtc://example.com\"},"      /* Unkown Tag is ignored */
+            "{\"Protocol\": \"WEBRTC\", \"Unkown\": \"webrtc://example.com\"}"               /* Unkown Tag is ignored */
+        "]"
+    "}";
+    size_t messageLength = strlen( message );
+    const char * wssURL = "wss://example.com";
+    const char * httpsURL = "https://example.com";
+    const char * webrtcURL = "webrtc://example.com";
+
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( message,
+                                                                 messageLength, &( endpoints ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( strlen( wssURL ),
+                       endpoints.wssEndpoint.endpointLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( wssURL, endpoints.wssEndpoint.pEndpoint, strlen( wssURL ) );
+    TEST_ASSERT_EQUAL( strlen( httpsURL ),
+                       endpoints.httpsEndpoint.endpointLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( httpsURL, endpoints.httpsEndpoint.pEndpoint, strlen( httpsURL ) );
+    TEST_ASSERT_EQUAL( strlen( webrtcURL ),
+                       endpoints.webrtcEndpoint.endpointLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( webrtcURL, endpoints.webrtcEndpoint.pEndpoint, strlen( webrtcURL ) );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Get Endpoint Response functionality.
+ */
+void test_signaling_ParseGetSignalingChannelEndpointResponse_SmallCaps( void )
+{
+    SignalingChannelEndpoints_t endpoints;
+    SignalingResult_t result;
+    const char *message = "{"
+        "\"ResourceEndpointList\": ["
+            "{\"Protocol\": \"wss\", \"ResourceEndpoint\": \"wss://example.com\"},"
+            "{\"Protocol\": \"https\", \"ResourceEndpoint\": \"https://example.com\"},"
+            "{\"Protocol\": \"webrtc\", \"ResourceEndpoint\": \"webrtc://example.com\"}"
+        "]"
+    "}";
+
+    size_t messageLength = strlen( message );
+    const char * wssURL = "wss://example.com";
+    const char * httpsURL = "https://example.com";
+    const char * webrtcURL = "webrtc://example.com";
+
+    result = Signaling_ParseGetSignalingChannelEndpointResponse( message,
+                                                                 messageLength, &( endpoints ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( strlen( wssURL ),
+                       endpoints.wssEndpoint.endpointLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( wssURL, endpoints.wssEndpoint.pEndpoint, strlen( wssURL ) );
+    TEST_ASSERT_EQUAL( strlen( httpsURL ),
+                       endpoints.httpsEndpoint.endpointLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( httpsURL, endpoints.httpsEndpoint.pEndpoint, strlen( httpsURL ) );
+    TEST_ASSERT_EQUAL( strlen( webrtcURL ),
+                       endpoints.webrtcEndpoint.endpointLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( webrtcURL, endpoints.webrtcEndpoint.pEndpoint, strlen( webrtcURL ) );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Get Ice Server Config Request fail functionality for Bad Parameters.
+ */
+void test_signaling_ConstructGetIceServerConfigRequest_BadParams( void )
+{
+    SignalingChannelEndpoint_t endpoint = { 0 };
+    GetIceServerConfigRequestInfo_t iceServerConfigRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
+
+    result = Signaling_ConstructGetIceServerConfigRequest( NULL,
+                                                           &( iceServerConfigRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    endpoint.pEndpoint = NULL;
+
+    result = Signaling_ConstructGetIceServerConfigRequest( &( endpoint ),
+                                                           &( iceServerConfigRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    endpoint.pEndpoint = "https://example.com";
+
+    result = Signaling_ConstructGetIceServerConfigRequest( &( endpoint ),
+                                                           &( iceServerConfigRequestInfo ), NULL );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    result = Signaling_ConstructGetIceServerConfigRequest( &( endpoint ),
+                                                           NULL, &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+    requestBuffer.pUrl = NULL;
+    result = Signaling_ConstructGetIceServerConfigRequest( &( endpoint ),
+                                                           &( iceServerConfigRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    requestBuffer.pUrl = "https://kinesisvideo.cn-east-1.amazonaws.com.cn/describeSignalingChannel";
+    requestBuffer.urlLength = strlen( requestBuffer.pUrl );
+    requestBuffer.pBody = NULL;
+    result = Signaling_ConstructGetIceServerConfigRequest( &( endpoint ),
+                                                           &( iceServerConfigRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    requestBuffer.pBody = "{\"ChannelName\":\"Test-Channel-China\"}";
+    requestBuffer.bodyLength = strlen( requestBuffer.pBody );
+    iceServerConfigRequestInfo.pClientId = NULL;
+    result = Signaling_ConstructGetIceServerConfigRequest( &( endpoint ),
+                                                           &( iceServerConfigRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Get Ice Server Config Request functionality.
+ */
+void test_signaling_ConstructGetIceServerConfigRequest_URLOutofMemory( void )
+{
+    SignalingChannelEndpoint_t endpoint = { 0 };
+    GetIceServerConfigRequestInfo_t iceServerConfigRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 20 ];                                       /* The url buffer is small */
+    char bodyBuffer[ 500 ];
+    SignalingResult_t result;
+
+    endpoint.pEndpoint = "https://example.com";
+    endpoint.endpointLength = strlen( endpoint.pEndpoint );
+
+    iceServerConfigRequestInfo.channelArn.pChannelArn = "arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123";
+    iceServerConfigRequestInfo.channelArn.channelArnLength = strlen( iceServerConfigRequestInfo.channelArn.pChannelArn );
+    iceServerConfigRequestInfo.pClientId = "Test-Client-Id";
+    iceServerConfigRequestInfo.clientIdLength = strlen( iceServerConfigRequestInfo.pClientId );
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructGetIceServerConfigRequest( &( endpoint ),
+                                                           &( iceServerConfigRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Get Ice Server Config Request functionality.
+ */
+void test_signaling_ConstructGetIceServerConfigRequest_BodyOutofMemory( void )
+{
+    SignalingChannelEndpoint_t endpoint = { 0 };
+    GetIceServerConfigRequestInfo_t iceServerConfigRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 10 ];           /* The body buffer is small */
+    SignalingResult_t result;
+
+    endpoint.pEndpoint = "https://example.com";
+    endpoint.endpointLength = strlen( endpoint.pEndpoint );
+
+    iceServerConfigRequestInfo.channelArn.pChannelArn = "arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123";
+    iceServerConfigRequestInfo.channelArn.channelArnLength = strlen( iceServerConfigRequestInfo.channelArn.pChannelArn );
+    iceServerConfigRequestInfo.pClientId = "Test-Client-Id";
+    iceServerConfigRequestInfo.clientIdLength = strlen( iceServerConfigRequestInfo.pClientId );
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructGetIceServerConfigRequest( &( endpoint ),
+                                                           &( iceServerConfigRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Get Ice Server Config Request functionality.
+ */
+void test_signaling_ConstructGetIceServerConfigRequest( void )
+{
+    SignalingChannelEndpoint_t endpoint = { 0 };
+    GetIceServerConfigRequestInfo_t iceServerConfigRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 500 ];
+    SignalingResult_t result;
+    const char * pExpectedUrl = "https://example.com/v1/get-ice-server-config";
+    const char * pExpectedBody = "{"
+                                    "\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\","
+                                    "\"ClientId\":\"Test-Client-Id\","
+                                    "\"Service\":\"TURN\""
+                                  "}";
+
+    endpoint.pEndpoint = "https://example.com";
+    endpoint.endpointLength = strlen( endpoint.pEndpoint );
+
+    iceServerConfigRequestInfo.channelArn.pChannelArn = "arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123";
+    iceServerConfigRequestInfo.channelArn.channelArnLength = strlen( iceServerConfigRequestInfo.channelArn.pChannelArn );
+    iceServerConfigRequestInfo.pClientId = "Test-Client-Id";
+    iceServerConfigRequestInfo.clientIdLength = strlen( iceServerConfigRequestInfo.pClientId );
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructGetIceServerConfigRequest( &( endpoint ),
+                                                           &( iceServerConfigRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
+                       requestBuffer.urlLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
+                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
+                       requestBuffer.bodyLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
+                              requestBuffer.pBody );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Ice Server Config Response fail functionality for Bad Parameters.
+ */
+void test_signaling_ParseGetIceServerConfigResponse_BadParams( void )
+{
+    const char * message = "Valid-Message";
+    size_t messageLength = strlen( message );
+    SignalingIceServer_t iceServers;
+    size_t numIceServers;
+    SignalingResult_t result;
+
+    result = Signaling_ParseGetIceServerConfigResponse( NULL,
+                                                        messageLength, &( iceServers ), &( numIceServers ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    result = Signaling_ParseGetIceServerConfigResponse( message,
+                                                        messageLength, NULL, &( numIceServers ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    result = Signaling_ParseGetIceServerConfigResponse( message,
+                                                        messageLength, &( iceServers ), NULL );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Ice Server Config Response functionality.
+ */
+void test_signaling_ParseGetIceServerConfigResponse_InvalidJson( void )
+{
+    SignalingIceServer_t iceServers[ 1 ];
+    size_t numIceServers = 1;
+    SignalingResult_t result;
+    const char * message = "{\"IceServerList\": [";             /* Missing closing bracket */
+    size_t messageLength = strlen( message );
+
+
+    result = Signaling_ParseGetIceServerConfigResponse( message,
+                                                        messageLength, &( iceServers[ 0 ] ), &( numIceServers ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
+                       result );
+
+    /*<----------------------------------------------------------------->*/
+
+    const char * message2 = "{"                      /* Empty JSON */
+                            "}";
+    size_t messageLength2 = strlen( message2 );
+
+
+    result = Signaling_ParseGetIceServerConfigResponse( message2,
+                                                        messageLength2, &( iceServers[ 0 ] ), &( numIceServers ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Ice Server Config Response functionality.
+ */
+void test_signaling_ParseGetIceServerConfigResponse_UnexpectedResponse( void )
+{
+    SignalingIceServer_t iceServers[ 1 ];
+    size_t numIceServers = 1;
+    SignalingResult_t result;
+    const char * message = "{"
+        "\"IceServerList\": {"          /* Opening Bracket Not JSON Array Type */
+            "{"
+                "\"Password\": \"password123\","
+                "\"Ttl\": 300,"
+                "\"Uris\": [\"turn:example.com:3478\"],"
+                "\"Username\": \"username123\""
+            "}"
+        "}"                             /* Closing Bracket not Not JSON Array Type */
+    "}";
+    size_t messageLength = strlen( message );
+
+
+    result = Signaling_ParseGetIceServerConfigResponse( message,
+                                                        messageLength, &( iceServers[ 0 ] ), &( numIceServers ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
+                       result );
+
+    /*<----------------------------------------------------------------->*/
+
+    const char * message2 = "{"
+        "\"Unkown\": ["                  /* Unkown Key */  
+            "{"
+                "\"Password\": \"password123\","
+                "\"Ttl\": 300,"
+                "\"Uris\": [\"turn:example.com:3478\"],"
+                "\"Username\": \"username123\""
+            "}"
+        "]"     
+    "}";              
+    size_t messageLength2 = strlen( message2 );
+
+
+    result = Signaling_ParseGetIceServerConfigResponse( message2,
+                                                        messageLength2, &( iceServers[ 0 ] ), &( numIceServers ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
+                       result );
+
+    /*<----------------------------------------------------------------->*/
+
+    const char * message3 = "{\"UnexpectedKey\": []}";               /* Unkown Key Though the length of "IceServerList" == "UnexpectedKey" */
+    size_t messageLength3 = strlen( message3 );
+
+
+    result = Signaling_ParseGetIceServerConfigResponse( message3,
+                                                        messageLength3, &( iceServers[ 0 ] ), &( numIceServers ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Ice Server Config Response functionality.
+ */
+void test_signaling_ParseGetIceServerConfigResponse_Parsing_InvalidTTL( void )
+{
+    SignalingIceServer_t iceServers[ 1 ];
+    size_t numIceServers = 1;
+    SignalingResult_t result;
+    const char * message = "{"
+        "\"IceServerList\": ["
+            "{"
+                "\"Password\": \"password123\","
+                "\"Ttl\": 30000000,"                                /* TTL value length > SIGNALING_ICE_SERVER_TTL_SECONDS_BUFFER_MAX ( 7 ) */
+                "\"Uris\": [\"turn:example.com:3478\"],"
+                "\"Username\": \"username123\""
+            "}"
+        "]"
+    "}";
+    size_t messageLength = strlen( message );
+
+
+    result = Signaling_ParseGetIceServerConfigResponse( message,
+                                                        messageLength, &( iceServers[ 0 ] ), &( numIceServers ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_TTL,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Ice Server Config Response functionality.
+ */
+void test_signaling_ParseGetIceServerConfigResponse_Parsing_LowTTL( void )
+{
+    SignalingIceServer_t iceServers[ 1 ];
+    size_t numIceServers = 1;
+    SignalingResult_t result;
+    const char * message = "{"
+        "\"IceServerList\": ["
+            "{"
+                "\"Password\": \"password123\","
+                "\"Ttl\": 15,"                                    /* TTL value < SIGNALING_ICE_SERVER_TTL_SECONDS_MIN (30) */
+                "\"Uris\": [\"turn:example.com:3478\"],"
+                "\"Username\": \"username123\""
+            "}"
+        "]"
+    "}";
+    size_t messageLength = strlen( message );
+
+
+    result = Signaling_ParseGetIceServerConfigResponse( message,
+                                                        messageLength, &( iceServers[ 0 ] ), &( numIceServers ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_TTL,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Ice Server Config Response functionality.
+ */
+void test_signaling_ParseGetIceServerConfigResponse_Parsing_HighTTL( void )
+{
+    SignalingIceServer_t iceServers[ 1 ];
+    size_t numIceServers = 1;
+    SignalingResult_t result;
+    const char * message = "{"
+        "\"IceServerList\": ["
+            "{"
+                "\"Password\": \"password123\","
+                "\"Ttl\": 86411,"                                   /* TTL value > SIGNALING_ICE_SERVER_TTL_SECONDS_MAX ( 86400 ) */
+                "\"Uris\": [\"turn:example.com:3478\"],"
+                "\"Username\": \"username123\""
+            "}"
+        "]"
+    "}";
+    size_t messageLength = strlen( message );
+
+
+    result = Signaling_ParseGetIceServerConfigResponse( message,
+                                                        messageLength, &( iceServers[ 0 ] ), &( numIceServers ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_TTL,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Ice Server Config Response functionality.
+ */
+void test_signaling_ParseGetIceServerConfigResponse( void )
+{
+    SignalingIceServer_t iceServers[ 1 ];
+    size_t numIceServers = 1;
+    SignalingResult_t result;
+    const char * message = "{"
+        "\"IceServerList\": ["
+            "{"
+                "\"Password\": \"password123\","
+                "\"Ttl\": 300,"
+                "\"Uris\": [\"turn:example.com:3478\"],"
+                "\"Username\": \"username123\","
+                "\"Unkown\": \"Unkown-Value\""              /* This Unkown Tag will be ignored. */
+            "}"
+        "]"
+    "}";
+    size_t messageLength = strlen( message );
+
+
+    result = Signaling_ParseGetIceServerConfigResponse( message,
+                                                        messageLength, &( iceServers[ 0 ] ), &( numIceServers ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( 1, numIceServers );
+    TEST_ASSERT_EQUAL_STRING_LEN( "password123", iceServers[ 0 ].pPassword, iceServers[ 0 ].passwordLength );
+    TEST_ASSERT_EQUAL( 300, iceServers[ 0 ].messageTtlSeconds );
+    TEST_ASSERT_EQUAL( 1, iceServers[ 0 ].urisNum );
+    TEST_ASSERT_EQUAL_STRING_LEN( "turn:example.com:3478", iceServers[ 0 ].pUris[ 0 ], iceServers[ 0 ].urisLength[ 0 ] );
+    TEST_ASSERT_EQUAL_STRING_LEN( "username123", iceServers[ 0 ].pUserName, iceServers[ 0 ].userNameLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Ice Server Config Response functionality.
+ */
+void test_signaling_ParseGetIceServerConfigResponse_Empty( void )
+{
+    SignalingIceServer_t iceServers[ 1 ];
+    size_t numIceServers = 1;
+    SignalingResult_t result;
+    const char * message = "{"
+        "\"IceServerList\": ["
+                                /* Empty Buffer will be ignored. */
+        "]"
+    "}";
+    size_t messageLength = strlen( message );
+
+
+    result = Signaling_ParseGetIceServerConfigResponse( message,
+                                                        messageLength, &( iceServers[ 0 ] ), &( numIceServers ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Join Storage Session Request fail functionality for Bad Parameters.
+ */
+void test_signaling_ConstructJoinStorageSessionRequest_BadParams( void )
+{
+    SignalingChannelEndpoint_t webrtcEndpoint = { 0 };
+    JoinStorageSessionRequestInfo_t joinStorageSessionRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
+
+    result = Signaling_ConstructJoinStorageSessionRequest( NULL,
+                                                           &( joinStorageSessionRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    webrtcEndpoint.pEndpoint = NULL;
+    result = Signaling_ConstructJoinStorageSessionRequest( &( webrtcEndpoint ),
+                                                           &( joinStorageSessionRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    webrtcEndpoint.pEndpoint = "webrtc://example.com";
+    webrtcEndpoint.endpointLength = strlen( webrtcEndpoint.pEndpoint );
+
+    result = Signaling_ConstructJoinStorageSessionRequest( &( webrtcEndpoint ),
+                                                           &( joinStorageSessionRequestInfo ), NULL );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+
+
+    result = Signaling_ConstructJoinStorageSessionRequest( &( webrtcEndpoint ),
+                                                           NULL, &( requestBuffer ) );
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    requestBuffer.pUrl = NULL;
+    result = Signaling_ConstructJoinStorageSessionRequest( &( webrtcEndpoint ),
+                                                           &( joinStorageSessionRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    requestBuffer.pUrl = "https://kinesisvideo.cn-east-1.amazonaws.com.cn/describeSignalingChannel";
+    requestBuffer.urlLength = strlen( requestBuffer.pUrl );
+    requestBuffer.pBody = NULL;
+
+    result = Signaling_ConstructJoinStorageSessionRequest( &( webrtcEndpoint ),
+                                                           &( joinStorageSessionRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    requestBuffer.pBody = "{\"ChannelName\":\"Test-Channel-China\"}";
+    requestBuffer.bodyLength = strlen( requestBuffer.pBody );
+    joinStorageSessionRequestInfo.channelArn.pChannelArn = NULL;
+
+    result = Signaling_ConstructJoinStorageSessionRequest( &( webrtcEndpoint ),
+                                                           &( joinStorageSessionRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Join Storage Session Request functionality.
+ */
+void test_signaling_ConstructJoinStorageSessionRequest_Master( void )
+{
+    SignalingChannelEndpoint_t webrtcEndpoint = { 0 };
+    JoinStorageSessionRequestInfo_t joinStorageSessionRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 500 ];
+    SignalingResult_t result;
+    const char * pExpectedUrl = "webrtc://example.com/joinStorageSession";
+    const char * pExpectedBody = "{"
+                                    "\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\""
+                                  "}";
+
+    webrtcEndpoint.pEndpoint = "webrtc://example.com";
+    webrtcEndpoint.endpointLength = strlen( webrtcEndpoint.pEndpoint );
+
+    joinStorageSessionRequestInfo.channelArn.pChannelArn = "arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123";
+    joinStorageSessionRequestInfo.channelArn.channelArnLength = strlen( joinStorageSessionRequestInfo.channelArn.pChannelArn );
+    joinStorageSessionRequestInfo.pClientId = NULL;
+    joinStorageSessionRequestInfo.clientIdLength = 0;
+    joinStorageSessionRequestInfo.role = SIGNALING_ROLE_MASTER;
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructJoinStorageSessionRequest( &( webrtcEndpoint ),
+                                                           &( joinStorageSessionRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK, result );
+    TEST_ASSERT_TRUE( strstr( requestBuffer.pBody, "\"clientId\"" ) == NULL );
+    TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
+                       requestBuffer.urlLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
+                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
+                       requestBuffer.bodyLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
+                              requestBuffer.pBody );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Join Storage Session Request functionality.
+ */
+void test_signaling_ConstructJoinStorageSessionRequest_Viewer( void )
+{
+    SignalingChannelEndpoint_t webrtcEndpoint = { 0 };
+    JoinStorageSessionRequestInfo_t joinStorageSessionRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 500 ];
+    SignalingResult_t result;
+    const char * pExpectedUrl = "webrtc://example.com/joinStorageSession";
+    const char * pExpectedBody = "{"
+                                    "\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\","
+                                    "\"ClientId\":\"TestClient\""
+                                  "}";
+
+    webrtcEndpoint.pEndpoint = "webrtc://example.com";
+    webrtcEndpoint.endpointLength = strlen( webrtcEndpoint.pEndpoint );
+
+    joinStorageSessionRequestInfo.channelArn.pChannelArn = "arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123";
+    joinStorageSessionRequestInfo.channelArn.channelArnLength = strlen( joinStorageSessionRequestInfo.channelArn.pChannelArn );
+    joinStorageSessionRequestInfo.pClientId = "TestClient";
+    joinStorageSessionRequestInfo.clientIdLength = strlen( joinStorageSessionRequestInfo.pClientId );
+    joinStorageSessionRequestInfo.role = SIGNALING_ROLE_VIEWER;
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructJoinStorageSessionRequest( &( webrtcEndpoint ),
+                                                           &( joinStorageSessionRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK, result );
+    TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
+                       requestBuffer.urlLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
+                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
+                       requestBuffer.bodyLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
+                              requestBuffer.pBody );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Join Storage Session Request functionality.
+ */
+void test_signaling_ConstructJoinStorageSessionRequest_URLOutofMemory( void )
+{
+    SignalingChannelEndpoint_t webrtcEndpoint = { 0 };
+    JoinStorageSessionRequestInfo_t joinStorageSessionRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 10 ];                    /* The url buffer is small */
+    char bodyBuffer[ 500 ];
+    SignalingResult_t result;
+
+    webrtcEndpoint.pEndpoint = "webrtc://example.com";
+    webrtcEndpoint.endpointLength = strlen( webrtcEndpoint.pEndpoint );
+
+    joinStorageSessionRequestInfo.channelArn.pChannelArn = "arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123";
+    joinStorageSessionRequestInfo.channelArn.channelArnLength = strlen( joinStorageSessionRequestInfo.channelArn.pChannelArn );
+    joinStorageSessionRequestInfo.pClientId = "TestClient";
+    joinStorageSessionRequestInfo.clientIdLength = strlen( joinStorageSessionRequestInfo.pClientId );
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructJoinStorageSessionRequest( &( webrtcEndpoint ),
+                                                           &( joinStorageSessionRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Join Storage Session Request functionality.
+ */
+void test_signaling_ConstructJoinStorageSessionRequest_BodyOutofMemory( void )
+{
+    SignalingChannelEndpoint_t webrtcEndpoint = { 0 };
+    JoinStorageSessionRequestInfo_t joinStorageSessionRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 10 ];                      /* The body buffer is small */
+    SignalingResult_t result;
+
+    webrtcEndpoint.pEndpoint = "webrtc://example.com";
+    webrtcEndpoint.endpointLength = strlen( webrtcEndpoint.pEndpoint );
+
+    joinStorageSessionRequestInfo.channelArn.pChannelArn = "arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123";
+    joinStorageSessionRequestInfo.channelArn.channelArnLength = strlen( joinStorageSessionRequestInfo.channelArn.pChannelArn );
+    joinStorageSessionRequestInfo.pClientId = "TestClient";
+    joinStorageSessionRequestInfo.clientIdLength = strlen( joinStorageSessionRequestInfo.pClientId );
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructJoinStorageSessionRequest( &( webrtcEndpoint ),
+                                                           &( joinStorageSessionRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY, result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Delete Signaling Channel Request fail functionality for Bad Parameters.
+ */
+void test_signaling_ConstructDeleteSignalingChannelRequest_BadParams( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    DeleteSignalingChannelRequestInfo_t deleteSignalingChannelRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
+
+    result = Signaling_ConstructDeleteSignalingChannelRequest( NULL,
+                                                               &( deleteSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    awsRegion.pAwsRegion = NULL;
+    result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
+                                                               &( deleteSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
+                                                               &( deleteSignalingChannelRequestInfo ), NULL );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+
+
+    result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
+                                                               NULL, &( requestBuffer ) );
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    requestBuffer.pUrl = NULL;
+    result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
+                                                               &( deleteSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    requestBuffer.pUrl = "https://kinesisvideo.cn-east-1.amazonaws.com.cn/describeSignalingChannel";
+    requestBuffer.urlLength = strlen( requestBuffer.pUrl );
+    requestBuffer.pBody = NULL;
+
+    result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
+                                                               &( deleteSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    requestBuffer.pBody = "{\"ChannelName\":\"Test-Channel-China\"}";
+    requestBuffer.bodyLength = strlen( requestBuffer.pBody );
+    deleteSignalingChannelRequestInfo.channelArn.pChannelArn = NULL;
+
+    result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
+                                                               &( deleteSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    deleteSignalingChannelRequestInfo.channelArn.pChannelArn = "arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123";
+    deleteSignalingChannelRequestInfo.channelArn.channelArnLength = strlen( deleteSignalingChannelRequestInfo.channelArn.pChannelArn );
+    deleteSignalingChannelRequestInfo.pVersion = NULL;
+
+    result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
+                                                               &( deleteSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Delete Signaling Channel Request functionality.
+ */
+void test_signaling_ConstructDeleteSignalingChannelRequest( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    DeleteSignalingChannelRequestInfo_t deleteSignalingChannelRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 500 ];
+    SignalingResult_t result;
+    const char * pExpectedUrl = "https://kinesisvideo.us-east-1.amazonaws.com/deleteSignalingChannel";
+    const char * pExpectedBody = "{"
+                                    "\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\","
+                                    "\"CurrentVersion\":\"1.0.0\""
+                                  "}";
+
+    awsRegion.pAwsRegion = "us-east-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    deleteSignalingChannelRequestInfo.channelArn.pChannelArn = "arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123";
+    deleteSignalingChannelRequestInfo.channelArn.channelArnLength = strlen( deleteSignalingChannelRequestInfo.channelArn.pChannelArn );
+    deleteSignalingChannelRequestInfo.pVersion = "1.0.0";
+    deleteSignalingChannelRequestInfo.versionLength = strlen( deleteSignalingChannelRequestInfo.pVersion );
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
+                                                               &( deleteSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
+                       requestBuffer.urlLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
+                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
+                       requestBuffer.bodyLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
+                              requestBuffer.pBody );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Delete Signaling Channel Request functionality.
+ */
+void test_signaling_ConstructDeleteSignalingChannelRequest_ChinaRegion( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    DeleteSignalingChannelRequestInfo_t deleteSignalingChannelRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 500 ];
+    SignalingResult_t result;
+    const char * pExpectedUrl = "https://kinesisvideo.cn-north-1.amazonaws.com.cn/deleteSignalingChannel";
+    const char * pExpectedBody = "{"
+                                    "\"ChannelARN\":\"arn:aws-cn:kinesisvideo:cn-north-1:123456789012:channel/test-channel/1234567890123\","
+                                    "\"CurrentVersion\":\"2.0.0\""
+                                  "}";
+
+    awsRegion.pAwsRegion = "cn-north-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    deleteSignalingChannelRequestInfo.channelArn.pChannelArn = "arn:aws-cn:kinesisvideo:cn-north-1:123456789012:channel/test-channel/1234567890123";
+    deleteSignalingChannelRequestInfo.channelArn.channelArnLength = strlen( deleteSignalingChannelRequestInfo.channelArn.pChannelArn );
+    deleteSignalingChannelRequestInfo.pVersion = "2.0.0";
+    deleteSignalingChannelRequestInfo.versionLength = strlen( deleteSignalingChannelRequestInfo.pVersion );
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
+                                                               &( deleteSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
+                       requestBuffer.urlLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
+                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
+                       requestBuffer.bodyLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
+                              requestBuffer.pBody );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Delete Signaling Channel Request functionality.
+ */
+void test_signaling_ConstructDeleteSignalingChannelRequest_SmallLengthRegion( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    DeleteSignalingChannelRequestInfo_t deleteSignalingChannelRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 500 ];
+    SignalingResult_t result;
+    const char * pExpectedUrl = "https://kinesisvideo.ca.amazonaws.com/deleteSignalingChannel";
+    const char * pExpectedBody = "{"
+                                    "\"ChannelARN\":\"arn:aws:kinesisvideo:ca:123456789012:channel/test-channel/1234567890123\","
+                                    "\"CurrentVersion\":\"2.0.0\""
+                                  "}";
+
+    awsRegion.pAwsRegion = "ca";            /* The Region Length is < 3 */
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    deleteSignalingChannelRequestInfo.channelArn.pChannelArn = "arn:aws:kinesisvideo:ca:123456789012:channel/test-channel/1234567890123";
+    deleteSignalingChannelRequestInfo.channelArn.channelArnLength = strlen( deleteSignalingChannelRequestInfo.channelArn.pChannelArn );
+    deleteSignalingChannelRequestInfo.pVersion = "2.0.0";
+    deleteSignalingChannelRequestInfo.versionLength = strlen( deleteSignalingChannelRequestInfo.pVersion );
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
+                                                               &( deleteSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
+                       requestBuffer.urlLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
+                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
+                       requestBuffer.bodyLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
+                              requestBuffer.pBody );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Delete Signaling Channel Request functionality.
+ */
+void test_signaling_ConstructDeleteSignalingChannelRequest_URL_OutofMemory( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    DeleteSignalingChannelRequestInfo_t deleteSignalingChannelRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 20 ];                   /* The url buffer is small */
+    char bodyBuffer[ 500 ];
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "cn-north-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    deleteSignalingChannelRequestInfo.channelArn.pChannelArn = "arn:aws-cn:kinesisvideo:cn-north-1:123456789012:channel/test-channel/1234567890123";
+    deleteSignalingChannelRequestInfo.channelArn.channelArnLength = strlen( deleteSignalingChannelRequestInfo.channelArn.pChannelArn );
+    deleteSignalingChannelRequestInfo.pVersion = "2.0.0";
+    deleteSignalingChannelRequestInfo.versionLength = strlen( deleteSignalingChannelRequestInfo.pVersion );
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
+                                                               &( deleteSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Delete Signaling Channel Request functionality.
+ */
+void test_signaling_ConstructDeleteSignalingChannelRequest_Body_OutofMemory( void )
+{
+    SignalingAwsRegion_t awsRegion = { 0 };
+    DeleteSignalingChannelRequestInfo_t deleteSignalingChannelRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 50 ];              /* The body buffer is small */
+    SignalingResult_t result;
+
+    awsRegion.pAwsRegion = "cn-north-1";
+    awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
+    deleteSignalingChannelRequestInfo.channelArn.pChannelArn = "arn:aws-cn:kinesisvideo:cn-north-1:123456789012:channel/test-channel/1234567890123";
+    deleteSignalingChannelRequestInfo.channelArn.channelArnLength = strlen( deleteSignalingChannelRequestInfo.channelArn.pChannelArn );
+    deleteSignalingChannelRequestInfo.pVersion = "2.0.0";
+    deleteSignalingChannelRequestInfo.versionLength = strlen( deleteSignalingChannelRequestInfo.pVersion );
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = bodyBuffer;
+    requestBuffer.bodyLength = sizeof( bodyBuffer );
+
+    result = Signaling_ConstructDeleteSignalingChannelRequest( &( awsRegion ),
+                                                               &( deleteSignalingChannelRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Connect Web-Sockets Endpoint Request fail functionality for Bad Parameters.
+ */
+void test_signaling_ConstructConnectWssEndpointRequest_BadParams( void )
+{
+    SignalingChannelEndpoint_t wssEndpoint = { 0 };
+    ConnectWssEndpointRequestInfo_t connectWssEndpointRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
+
+    result = Signaling_ConstructConnectWssEndpointRequest( NULL,
+                                                           &( connectWssEndpointRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    wssEndpoint.pEndpoint = NULL;
+    result = Signaling_ConstructConnectWssEndpointRequest( &( wssEndpoint ),
+                                                           &( connectWssEndpointRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    wssEndpoint.pEndpoint = "wss://example.com";
+    wssEndpoint.endpointLength = strlen( wssEndpoint.pEndpoint );
+
+    result = Signaling_ConstructConnectWssEndpointRequest( &( wssEndpoint ),
+                                                           &( connectWssEndpointRequestInfo ), NULL );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+
+
+    result = Signaling_ConstructConnectWssEndpointRequest( &( wssEndpoint ),
+                                                           NULL, &( requestBuffer ) );
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    requestBuffer.pUrl = NULL;
+    result = Signaling_ConstructConnectWssEndpointRequest( &( wssEndpoint ),
+                                                           &( connectWssEndpointRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    requestBuffer.pUrl = "https://kinesisvideo.cn-east-1.amazonaws.com.cn/describeSignalingChannel";
+    requestBuffer.urlLength = strlen( requestBuffer.pUrl );
+    connectWssEndpointRequestInfo.channelArn.pChannelArn = NULL;
+
+    result = Signaling_ConstructConnectWssEndpointRequest( &( wssEndpoint ),
+                                                           &( connectWssEndpointRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    connectWssEndpointRequestInfo.channelArn.pChannelArn = "arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123";
+    connectWssEndpointRequestInfo.channelArn.channelArnLength = strlen( connectWssEndpointRequestInfo.channelArn.pChannelArn );
+    connectWssEndpointRequestInfo.role = SIGNALING_ROLE_NONE;
+
+    result = Signaling_ConstructConnectWssEndpointRequest( &( wssEndpoint ),
+                                                           &( connectWssEndpointRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    connectWssEndpointRequestInfo.role = SIGNALING_ROLE_VIEWER;
+    connectWssEndpointRequestInfo.pClientId = NULL;
+
+    result = Signaling_ConstructConnectWssEndpointRequest( &( wssEndpoint ),
+                                                           &( connectWssEndpointRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Connect Web-Sockets Endpoint Request fail functionality for Bad Parameters.
+ */
+void test_signaling_ConstructConnectWssEndpointRequest_Master( void )
+{
+    SignalingChannelEndpoint_t wssEndpoint = { 0 };
+    ConnectWssEndpointRequestInfo_t connectWssEndpointRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 300 ];
+    SignalingResult_t result;
+    const char * pExpectedUrl = "wss://example.com?X-Amz-ChannelARN=arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123";
+
+    wssEndpoint.pEndpoint = "wss://example.com";
+    wssEndpoint.endpointLength = strlen( wssEndpoint.pEndpoint );
+
+    connectWssEndpointRequestInfo.channelArn.pChannelArn = "arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123";
+    connectWssEndpointRequestInfo.channelArn.channelArnLength = strlen( connectWssEndpointRequestInfo.channelArn.pChannelArn );
+    connectWssEndpointRequestInfo.role = SIGNALING_ROLE_MASTER;
+    connectWssEndpointRequestInfo.pClientId = NULL;
+    connectWssEndpointRequestInfo.clientIdLength = 0;
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = NULL;
+    requestBuffer.bodyLength = 0;
+
+    result = Signaling_ConstructConnectWssEndpointRequest( &( wssEndpoint ),
+                                                           &( connectWssEndpointRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_TRUE( strstr( requestBuffer.pUrl, "X-Amz-ClientId" ) == NULL );
+    TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
+                       requestBuffer.urlLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
+                              requestBuffer.pUrl );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Connect Web-Sockets Endpoint Request fail functionality for Bad Parameters.
+ */
+void test_signaling_ConstructConnectWssEndpointRequest_Viewer( void )
+{
+    SignalingChannelEndpoint_t wssEndpoint = { 0 };
+    ConnectWssEndpointRequestInfo_t connectWssEndpointRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 300 ];
+    SignalingResult_t result;
+    const char * pExpectedUrl = "wss://example.com?X-Amz-ChannelARN=arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123&X-Amz-ClientId=TestClient";
+
+    wssEndpoint.pEndpoint = "wss://example.com";
+    wssEndpoint.endpointLength = strlen( wssEndpoint.pEndpoint );
+
+    connectWssEndpointRequestInfo.channelArn.pChannelArn = "arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123";
+    connectWssEndpointRequestInfo.channelArn.channelArnLength = strlen( connectWssEndpointRequestInfo.channelArn.pChannelArn );
+    connectWssEndpointRequestInfo.role = SIGNALING_ROLE_VIEWER;
+    connectWssEndpointRequestInfo.pClientId = "TestClient";
+    connectWssEndpointRequestInfo.clientIdLength = strlen( connectWssEndpointRequestInfo.pClientId );
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = NULL;
+    requestBuffer.bodyLength = 0;
+
+    result = Signaling_ConstructConnectWssEndpointRequest( &( wssEndpoint ),
+                                                           &( connectWssEndpointRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_TRUE( strstr( requestBuffer.pUrl, "X-Amz-ClientId=TestClient" ) != NULL );
+    TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
+                       requestBuffer.urlLength );
+    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
+                              requestBuffer.pUrl );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Connect Web-Sockets Endpoint Request fail functionality for Bad Parameters.
+ */
+void test_signaling_ConstructConnectWssEndpointRequest_Url_OutofMemory( void )
+{
+    SignalingChannelEndpoint_t wssEndpoint = { 0 };
+    ConnectWssEndpointRequestInfo_t connectWssEndpointRequestInfo = { 0 };
+    SignalingRequest_t requestBuffer = { 0 };
+    char urlBuffer[ 30 ];                     /* The url buffer is small */
+    SignalingResult_t result;
+
+    wssEndpoint.pEndpoint = "wss://example.com";
+    wssEndpoint.endpointLength = strlen( wssEndpoint.pEndpoint );
+
+    connectWssEndpointRequestInfo.channelArn.pChannelArn = "arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123";
+    connectWssEndpointRequestInfo.channelArn.channelArnLength = strlen( connectWssEndpointRequestInfo.channelArn.pChannelArn );
+    connectWssEndpointRequestInfo.role = SIGNALING_ROLE_VIEWER;
+    connectWssEndpointRequestInfo.pClientId = "TestClient";
+    connectWssEndpointRequestInfo.clientIdLength = strlen( connectWssEndpointRequestInfo.pClientId );
+
+    requestBuffer.pUrl = urlBuffer;
+    requestBuffer.urlLength = sizeof( urlBuffer );
+    requestBuffer.pBody = NULL;
+    requestBuffer.bodyLength = 0;
+
+    result = Signaling_ConstructConnectWssEndpointRequest( &( wssEndpoint ),
+                                                           &( connectWssEndpointRequestInfo ), &( requestBuffer ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Web-Socket Message fail functionality for Bad Parameters.
+ */
+void test_signaling_ConstructWssMessage_BadParams( void )
+{
+    WssSendMessage_t wssSendMessage = { 0 };
+    char messageBuffer[ 300 ];
+    size_t messageBufferLength = sizeof( messageBuffer );
+    SignalingResult_t result;
+
+    result = Signaling_ConstructWssMessage( NULL,
+                                            &( messageBuffer[ 0 ] ), &( messageBufferLength ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    result = Signaling_ConstructWssMessage( &( wssSendMessage ),
+                                            NULL, &( messageBufferLength ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    wssSendMessage.pBase64EncodedMessage = NULL;
+
+    result = Signaling_ConstructWssMessage( &( wssSendMessage ),
+                                            &( messageBuffer[ 0 ] ), &( messageBufferLength ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    wssSendMessage.pBase64EncodedMessage = "TestMessage";
+    wssSendMessage.base64EncodedMessageLength = strlen( wssSendMessage.pBase64EncodedMessage );
+    wssSendMessage.pRecipientClientId = NULL;
+
+    result = Signaling_ConstructWssMessage( &( wssSendMessage ),
+                                            &( messageBuffer[ 0 ] ), &( messageBufferLength ) );
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Web-Socket Message functionality.
+ */
+void test_signaling_ConstructWssMessage_SdpOffer( void )
+{
+    WssSendMessage_t wssSendMessage = { 0 };
+    char messageBuffer[ 300 ];
+    size_t messageBufferLength = sizeof( messageBuffer );
+    SignalingResult_t result;
+    const char * pExpectedMessage = "{"
+                                        "\"action\":\"SDP_OFFER\","
+                                        "\"RecipientClientId\":\"TestClientId\","
+                                        "\"MessagePayload\":\"base64encodedmessage\","
+                                        "\"CorrelationId\":\"TestCorrelationId\""
+                                    "}";
+
+    wssSendMessage.messageType = SIGNALING_TYPE_MESSAGE_SDP_OFFER;
+    wssSendMessage.pBase64EncodedMessage = "base64encodedmessage";
+    wssSendMessage.base64EncodedMessageLength = strlen( wssSendMessage.pBase64EncodedMessage );
+    wssSendMessage.pRecipientClientId = "TestClientId";
+    wssSendMessage.recipientClientIdLength = strlen( wssSendMessage.pRecipientClientId );
+    wssSendMessage.pCorrelationId = "TestCorrelationId";
+    wssSendMessage.correlationIdLength = strlen( wssSendMessage.pCorrelationId );
+
+    result = Signaling_ConstructWssMessage( &( wssSendMessage ),
+                                            messageBuffer, &( messageBufferLength ) );
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( strlen( pExpectedMessage ),
+                       strlen( messageBuffer ) );
+    TEST_ASSERT_EQUAL_STRING( pExpectedMessage,
+                              messageBuffer );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Web-Socket Message functionality.
+ */
+void test_signaling_ConstructWssMessage_SdpAnswer( void )
+{
+    WssSendMessage_t wssSendMessage = { 0 };
+    char messageBuffer[ 300 ];
+    size_t messageBufferLength = sizeof( messageBuffer );
+    SignalingResult_t result;
+    const char * pExpectedMessage = "{"
+                                        "\"action\":\"SDP_ANSWER\","
+                                        "\"RecipientClientId\":\"TestClientId\","
+                                        "\"MessagePayload\":\"base64encodedmessage\","
+                                        "\"CorrelationId\":\"TestCorrelationId\""
+                                    "}";
+
+    wssSendMessage.messageType = SIGNALING_TYPE_MESSAGE_SDP_ANSWER;
+    wssSendMessage.pBase64EncodedMessage = "base64encodedmessage";
+    wssSendMessage.base64EncodedMessageLength = strlen( wssSendMessage.pBase64EncodedMessage );
+    wssSendMessage.pRecipientClientId = "TestClientId";
+    wssSendMessage.recipientClientIdLength = strlen( wssSendMessage.pRecipientClientId );
+    wssSendMessage.pCorrelationId = "TestCorrelationId";
+    wssSendMessage.correlationIdLength = strlen( wssSendMessage.pCorrelationId );
+
+    result = Signaling_ConstructWssMessage( &( wssSendMessage ),
+                                            messageBuffer, &( messageBufferLength ) );
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( strlen( pExpectedMessage ),
+                       strlen( messageBuffer ) );
+    TEST_ASSERT_EQUAL_STRING( pExpectedMessage,
+                              messageBuffer );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Web-Socket Message functionality.
+ */
+void test_signaling_ConstructWssMessage_IceCandidate( void )
+{
+    WssSendMessage_t wssSendMessage = { 0 };
+    char messageBuffer[ 300 ];
+    size_t messageBufferLength = sizeof( messageBuffer );
+    SignalingResult_t result;
+    const char * pExpectedMessage = "{"
+                                        "\"action\":\"ICE_CANDIDATE\","
+                                        "\"RecipientClientId\":\"TestClientId\","
+                                        "\"MessagePayload\":\"base64encodedmessage\","
+                                        "\"CorrelationId\":\"TestCorrelationId\""
+                                    "}";
+
+    wssSendMessage.messageType = SIGNALING_TYPE_MESSAGE_ICE_CANDIDATE;
+    wssSendMessage.pBase64EncodedMessage = "base64encodedmessage";
+    wssSendMessage.base64EncodedMessageLength = strlen( wssSendMessage.pBase64EncodedMessage );
+    wssSendMessage.pRecipientClientId = "TestClientId";
+    wssSendMessage.recipientClientIdLength = strlen( wssSendMessage.pRecipientClientId );
+    wssSendMessage.pCorrelationId = "TestCorrelationId";
+    wssSendMessage.correlationIdLength = strlen( wssSendMessage.pCorrelationId );
+
+    result = Signaling_ConstructWssMessage( &( wssSendMessage ),
+                                            messageBuffer, &( messageBufferLength ) );
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( strlen( pExpectedMessage ),
+                       strlen( messageBuffer ) );
+    TEST_ASSERT_EQUAL_STRING( pExpectedMessage,
+                              messageBuffer );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Web-Socket Message functionality.
+ */
+void test_signaling_ConstructWssMessage_Unkown( void )
+{
+    WssSendMessage_t wssSendMessage = { 0 };
+    char messageBuffer[ 300 ];
+    size_t messageBufferLength = sizeof( messageBuffer );
+    SignalingResult_t result;
+    const char * pExpectedMessage = "{"
+                                        "\"action\":\"UNKNOWN\","
+                                        "\"RecipientClientId\":\"TestClientId\","
+                                        "\"MessagePayload\":\"base64encodedmessage\","
+                                        "\"CorrelationId\":\"TestCorrelationId\""
+                                    "}";
+
+    wssSendMessage.messageType = SIGNALING_TYPE_MESSAGE_UNKNOWN;
+    wssSendMessage.pBase64EncodedMessage = "base64encodedmessage";
+    wssSendMessage.base64EncodedMessageLength = strlen( wssSendMessage.pBase64EncodedMessage );
+    wssSendMessage.pRecipientClientId = "TestClientId";
+    wssSendMessage.recipientClientIdLength = strlen( wssSendMessage.pRecipientClientId );
+    wssSendMessage.pCorrelationId = "TestCorrelationId";
+    wssSendMessage.correlationIdLength = strlen( wssSendMessage.pCorrelationId );
+
+    result = Signaling_ConstructWssMessage( &( wssSendMessage ),
+                                            messageBuffer, &( messageBufferLength ) );
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( strlen( pExpectedMessage ),
+                       strlen( messageBuffer ) );
+    TEST_ASSERT_EQUAL_STRING( pExpectedMessage,
+                              messageBuffer );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Web-Socket Message functionality.
+ */
+void test_signaling_ConstructWssMessage_OutofMemory( void )
+{
+    WssSendMessage_t wssSendMessage = { 0 };
+    char messageBuffer[ 100 ];                  /* Correlation ID is not added in the buffer properly */
+    size_t messageBufferLength = sizeof( messageBuffer );
+    SignalingResult_t result;
+
+    wssSendMessage.messageType = SIGNALING_TYPE_MESSAGE_SDP_OFFER;
+    wssSendMessage.pBase64EncodedMessage = "base64encodedmessage";
+    wssSendMessage.base64EncodedMessageLength = strlen( wssSendMessage.pBase64EncodedMessage );
+    wssSendMessage.pRecipientClientId = "TestClientId";
+    wssSendMessage.recipientClientIdLength = strlen( wssSendMessage.pRecipientClientId );
+    wssSendMessage.pCorrelationId = "TestCorrelationId";
+    wssSendMessage.correlationIdLength = strlen( wssSendMessage.pCorrelationId );
+
+    result = Signaling_ConstructWssMessage( &( wssSendMessage ),
+                                            messageBuffer, &( messageBufferLength ) );
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Web-Socket Message functionality.
+ */
+void test_signaling_ConstructWssMessage_OutofMemory_ClosingBracket( void )
+{
+    WssSendMessage_t wssSendMessage = { 0 };
+    char messageBuffer[ 133 ];                  /* Closing is not added in the buffer properly */
+    size_t messageBufferLength = sizeof( messageBuffer );
+    SignalingResult_t result;
+
+    wssSendMessage.messageType = SIGNALING_TYPE_MESSAGE_SDP_OFFER;
+    wssSendMessage.pBase64EncodedMessage = "base64encodedmessage";
+    wssSendMessage.base64EncodedMessageLength = strlen( wssSendMessage.pBase64EncodedMessage );
+    wssSendMessage.pRecipientClientId = "TestClientId";
+    wssSendMessage.recipientClientIdLength = strlen( wssSendMessage.pRecipientClientId );
+    wssSendMessage.pCorrelationId = "TestCorrelationId";
+    wssSendMessage.correlationIdLength = strlen( wssSendMessage.pCorrelationId );
+
+    result = Signaling_ConstructWssMessage( &( wssSendMessage ),
+                                            messageBuffer, &( messageBufferLength ) );
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Web-Socket Message functionality.
+ */
+void test_signaling_ConstructWssMessage_NoCorrelationId( void )
+{
+    WssSendMessage_t wssSendMessage = { 0 };
+    char messageBuffer[ 300 ];
+    size_t messageBufferLength = sizeof( messageBuffer );
+    SignalingResult_t result;
+    const char * pExpectedMessage = "{"
+                                        "\"action\":\"SDP_OFFER\","
+                                        "\"RecipientClientId\":\"TestClientId\","
+                                        "\"MessagePayload\":\"base64encodedmessage\""
+                                    "}";
+
+    wssSendMessage.messageType = SIGNALING_TYPE_MESSAGE_SDP_OFFER;
+    wssSendMessage.pBase64EncodedMessage = "base64encodedmessage";
+    wssSendMessage.base64EncodedMessageLength = strlen( wssSendMessage.pBase64EncodedMessage );
+    wssSendMessage.pRecipientClientId = "TestClientId";
+    wssSendMessage.recipientClientIdLength = strlen( wssSendMessage.pRecipientClientId );
+    wssSendMessage.pCorrelationId = NULL;
+    wssSendMessage.correlationIdLength = 0;
+
+    result = Signaling_ConstructWssMessage( &( wssSendMessage ),
+                                            messageBuffer, &( messageBufferLength ) );
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( strlen( pExpectedMessage ),
+                       strlen( messageBuffer ) );
+    TEST_ASSERT_EQUAL_STRING( pExpectedMessage,
+                              messageBuffer );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Web-Socket Message functionality.
+ */
+void test_signaling_ConstructWssMessage_SmallBuffer( void )
+{
+    WssSendMessage_t wssSendMessage = { 0 };
+    char messageBuffer[ 10 ];                           /* A small Message Buffer */
+    size_t messageBufferLength = sizeof( messageBuffer );
+    SignalingResult_t result;
+
+    wssSendMessage.messageType = SIGNALING_TYPE_MESSAGE_SDP_OFFER;
+    wssSendMessage.pBase64EncodedMessage = "base64encodedmessage";
+    wssSendMessage.base64EncodedMessageLength = strlen( wssSendMessage.pBase64EncodedMessage );
+    wssSendMessage.pRecipientClientId = "TestClientId";
+    wssSendMessage.recipientClientIdLength = strlen( wssSendMessage.pRecipientClientId );
+    wssSendMessage.pCorrelationId = "correlation123";
+    wssSendMessage.correlationIdLength = strlen( wssSendMessage.pCorrelationId );
+
+    result = Signaling_ConstructWssMessage( &( wssSendMessage ),
+                                            messageBuffer, &( messageBufferLength ) );
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
+                       result );
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Web-Socket Receive Message fail functionality for Bad Parameters.
+ */
+void test_signaling_ParseWssRecvMessage_BadParams( void )
+{
+    WssRecvMessage_t wssRecvMessage = { 0 };
+    const char message[ 300 ] = "XXXXXXXXXXX";
+    size_t messageLength = strlen( message );
+    SignalingResult_t result;
+
+    result = Signaling_ParseWssRecvMessage( NULL,
+                                            messageLength, &( wssRecvMessage ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    /*      <------------------------------------------------------------------------------------------>      */
+
+    result = Signaling_ParseWssRecvMessage( message,
+                                            messageLength, NULL );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Web-Socket Receive Message functionality.
+ */
+void test_signaling_ParseWssRecvMessage_Sdp_Offer( void )
+{
+    SignalingResult_t result;
+    WssRecvMessage_t wssRecvMessage = { 0 };
+    const char * message = "{"
+        "\"senderClientId\":\"sender123\","
+        "\"messageType\":\"SDP_OFFER\","
+        "\"messagePayload\":\"base64encodedpayload\""
+    "}";
+    size_t messageLength = strlen( message );
+
+    result = Signaling_ParseWssRecvMessage( message,
+                                            messageLength, &( wssRecvMessage ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL_STRING_LEN( "sender123", wssRecvMessage.pSenderClientId, wssRecvMessage.senderClientIdLength );
+    TEST_ASSERT_EQUAL( SIGNALING_TYPE_MESSAGE_SDP_OFFER, wssRecvMessage.messageType );
+    TEST_ASSERT_EQUAL_STRING_LEN( "base64encodedpayload", wssRecvMessage.pBase64EncodedPayload, wssRecvMessage.base64EncodedPayloadLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Web-Socket Receive Message functionality.
+ */
+void test_signaling_ParseWssRecvMessage_Sdp_Answer( void )
+{
+    SignalingResult_t result;
+    WssRecvMessage_t wssRecvMessage = { 0 };
+    const char *message = "{"
+        "\"senderClientId\":\"sender123\","
+        "\"messageType\":\"SDP_ANSWER\","
+        "\"messagePayload\":\"base64encodedpayload\""
+    "}";
+    size_t messageLength = strlen( message );
+
+    result = Signaling_ParseWssRecvMessage( message,
+                                            messageLength, &( wssRecvMessage ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL_STRING_LEN( "sender123", wssRecvMessage.pSenderClientId, wssRecvMessage.senderClientIdLength );
+    TEST_ASSERT_EQUAL( SIGNALING_TYPE_MESSAGE_SDP_ANSWER, wssRecvMessage.messageType );
+    TEST_ASSERT_EQUAL_STRING_LEN( "base64encodedpayload", wssRecvMessage.pBase64EncodedPayload, wssRecvMessage.base64EncodedPayloadLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Web-Socket Receive Message functionality.
+ */
+void test_signaling_ParseWssRecvMessage_IceCandidate( void )
+{
+    SignalingResult_t result;
+    WssRecvMessage_t wssRecvMessage = { 0 };
+    const char *message = "{"
+        "\"senderClientId\":\"sender123\","
+        "\"messageType\":\"ICE_CANDIDATE\","
+        "\"messagePayload\":\"base64encodedpayload\""
+    "}";
+    size_t messageLength = strlen( message );
+
+    result = Signaling_ParseWssRecvMessage( message,
+                                            messageLength, &( wssRecvMessage ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL_STRING_LEN( "sender123", wssRecvMessage.pSenderClientId, wssRecvMessage.senderClientIdLength );
+    TEST_ASSERT_EQUAL( SIGNALING_TYPE_MESSAGE_ICE_CANDIDATE, wssRecvMessage.messageType );
+    TEST_ASSERT_EQUAL_STRING_LEN( "base64encodedpayload", wssRecvMessage.pBase64EncodedPayload, wssRecvMessage.base64EncodedPayloadLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Web-Socket Receive Message functionality.
+ */
+void test_signaling_ParseWssRecvMessage_GoAway( void )
+{
+    SignalingResult_t result;
+    WssRecvMessage_t wssRecvMessage = { 0 };
+    const char *message = "{"
+        "\"senderClientId\":\"sender123\","
+        "\"messageType\":\"GO_AWAY\","
+        "\"messagePayload\":\"base64encodedpayload\""
+    "}";
+    size_t messageLength = strlen( message );
+
+    result = Signaling_ParseWssRecvMessage( message,
+                                            messageLength, &( wssRecvMessage ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL_STRING_LEN( "sender123", wssRecvMessage.pSenderClientId, wssRecvMessage.senderClientIdLength );
+    TEST_ASSERT_EQUAL( SIGNALING_TYPE_MESSAGE_GO_AWAY, wssRecvMessage.messageType );
+    TEST_ASSERT_EQUAL_STRING_LEN( "base64encodedpayload", wssRecvMessage.pBase64EncodedPayload, wssRecvMessage.base64EncodedPayloadLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Web-Socket Receive Message functionality.
+ */
+void test_signaling_ParseWssRecvMessage_ExcludeNullTerminator( void )
+{
+    SignalingResult_t result;
+    WssRecvMessage_t wssRecvMessage = { 0 };
+    const char *message = "{"
+        "\"senderClientId\":\"sender123\","
+        "\"messageType\":\"RECONNECT_ICE_SERVER\","
+        "\"messagePayload\":\"base64encodedpayload\""
+    "}\0";          // Explicitly include null terminator
+    size_t messageLength = strlen(message) + 1 ;                 // Length including null terminator
+
+    result = Signaling_ParseWssRecvMessage( message,
+                                            messageLength, &( wssRecvMessage ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL_STRING_LEN( "sender123", wssRecvMessage.pSenderClientId, wssRecvMessage.senderClientIdLength );
+    TEST_ASSERT_EQUAL( SIGNALING_TYPE_MESSAGE_RECONNECT_ICE_SERVER, wssRecvMessage.messageType );
+    TEST_ASSERT_EQUAL_STRING_LEN( "base64encodedpayload", wssRecvMessage.pBase64EncodedPayload, wssRecvMessage.base64EncodedPayloadLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Web-Socket Receive Message functionality.
+ */
+void test_signaling_ParseWssRecvMessage_ReconnectIceServer( void )
+{
+    SignalingResult_t result;
+    WssRecvMessage_t wssRecvMessage = { 0 };
+    const char *message = "{"
+        "\"senderClientId\":\"sender123\","
+        "\"messageType\":\"RECONNECT_ICE_SERVER\","
+        "\"messagePayload\":\"base64encodedpayload\""
+    "}";
+    size_t messageLength = strlen( message );
+
+    result = Signaling_ParseWssRecvMessage( message,
+                                            messageLength, &( wssRecvMessage ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL_STRING_LEN( "sender123", wssRecvMessage.pSenderClientId, wssRecvMessage.senderClientIdLength );
+    TEST_ASSERT_EQUAL( SIGNALING_TYPE_MESSAGE_RECONNECT_ICE_SERVER, wssRecvMessage.messageType );
+    TEST_ASSERT_EQUAL_STRING_LEN( "base64encodedpayload", wssRecvMessage.pBase64EncodedPayload, wssRecvMessage.base64EncodedPayloadLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Web-Socket Receive Message functionality.
+ */
+void test_signaling_ParseWssRecvMessage_StatusResponse( void )
+{
+    SignalingResult_t result;
+    WssRecvMessage_t wssRecvMessage = { 0 };
+    const char *message = "{"
+        "\"messageType\":\"STATUS_RESPONSE\","
+        "\"statusResponse\":{"
+            "\"correlationId\":\"corr123\","
+            "\"errorType\":\"None\","
+            "\"statusCode\":\"200\","
+            "\"description\":\"OK\","
+            "\"Unkown\":\"value\""                   /* Unkown Tags are ignored. */
+        "}"
+    "}";
+    size_t messageLength = strlen( message );
+
+    result = Signaling_ParseWssRecvMessage( message,
+                                            messageLength, &( wssRecvMessage ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( SIGNALING_TYPE_MESSAGE_STATUS_RESPONSE, wssRecvMessage.messageType );
+    TEST_ASSERT_EQUAL_STRING_LEN( "corr123", wssRecvMessage.statusResponse.pCorrelationId, wssRecvMessage.statusResponse.correlationIdLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "None", wssRecvMessage.statusResponse.pErrorType, wssRecvMessage.statusResponse.errorTypeLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "200", wssRecvMessage.statusResponse.pStatusCode, wssRecvMessage.statusResponse.statusCodeLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( "OK", wssRecvMessage.statusResponse.pDescription, wssRecvMessage.statusResponse.descriptionLength );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Web-Socket Receive Message functionality.
+ */
+void test_signaling_ParseWssRecvMessage_InvalidJson( void )
+{
+    SignalingResult_t result;
+    WssRecvMessage_t wssRecvMessage = { 0 };
+    const char * message = "{\"senderClientId\":\"sender123\",";  /* Missing closing brace */
+    size_t messageLength = strlen( message );
+
+    result = Signaling_ParseWssRecvMessage( message,
+                                            messageLength, &( wssRecvMessage ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Web-Socket Receive Message functionality.
+ */
+void test_signaling_ParseWssRecvMessage_UnkownMessageType( void )
+{
+    SignalingResult_t result;
+    WssRecvMessage_t wssRecvMessage = { 0 };
+    const char *message  = "{"
+        "\"senderClientId\":\"sender123\","
+        "\"messageType\":\"UNKNOWN_TYPE\","                 /* Unkown Message Type */
+        "\"messagePayload\":\"base64encodedpayload\","
+        "\"Unkown\":\"unkown-value\""                       /* This Unkown Tag is ignored */
+    "}";
+    size_t messageLength = strlen( message );
+
+    result = Signaling_ParseWssRecvMessage( message,
+                                            messageLength, &( wssRecvMessage ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( SIGNALING_TYPE_MESSAGE_UNKNOWN, wssRecvMessage.messageType );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Web-Socket Receive Message functionality.
+ */
+void test_signaling_ParseWssRecvMessage_UnexpectedStatusResponse( void )
+{
+    SignalingResult_t result;
+    WssRecvMessage_t wssRecvMessage = { 0 };
+    const char *message  = "{"
+        "\"messageType\":\"STATUS_RESPONSE\","
+        "\"statusResponse\":\"invalid\""            /* Invalid Status Response */
+    "}";
+    size_t messageLength = strlen( message );
+
+    result = Signaling_ParseWssRecvMessage( message,
+                                            messageLength, &( wssRecvMessage ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Web-Socket Receive Message functionality.
+ */
+void test_signaling_ParseWssRecvMessage_InvalidStatusResponse( void )
+{
+    SignalingResult_t result;
+    WssRecvMessage_t wssRecvMessage = { 0 };
+    const char *message  = "{"
+        "\"messageType\":\"STATUS_RESPONSE\","
+        "\"statusResponse\":{"                                      /* Empty Status Response */
+        "}"
+    "}";
+    size_t messageLength = strlen( message );
+
+    result = Signaling_ParseWssRecvMessage( message,
+                                            messageLength, &( wssRecvMessage ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_STATUS_RESPONSE,
+                       result );
 }
 
 /*-----------------------------------------------------------*/

--- a/test/unit-test/signaling_api/signaling_api_utest.c
+++ b/test/unit-test/signaling_api/signaling_api_utest.c
@@ -1151,35 +1151,43 @@ void test_signaling_ConstructCreateSignalingChannelRequest_BadParams( void )
     SignalingResult_t result;
 
     result = Signaling_ConstructCreateSignalingChannelRequest( NULL,
-                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( createSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     awsRegion.pAwsRegion = NULL;
+
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
-                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( createSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
+
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
-                                                               NULL, &( requestBuffer ) );
+                                                               NULL,
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
-                                                               &( createSignalingChannelRequestInfo ), NULL );
+                                                               &( createSignalingChannelRequestInfo ),
+                                                               NULL );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     requestBuffer.pUrl = NULL;
+
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
-                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( createSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -1189,7 +1197,8 @@ void test_signaling_ConstructCreateSignalingChannelRequest_BadParams( void )
     requestBuffer.pBody = NULL;
 
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
-                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( createSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -1200,15 +1209,18 @@ void test_signaling_ConstructCreateSignalingChannelRequest_BadParams( void )
     createSignalingChannelRequestInfo.pTags = NULL;
 
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
-                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( createSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     createSignalingChannelRequestInfo.pTags = &( tags[ 0 ] );
     createSignalingChannelRequestInfo.channelName.channelNameLength = SIGNALING_CHANNEL_NAME_MAX_LEN + 1;
+
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
-                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( createSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -1219,14 +1231,14 @@ void test_signaling_ConstructCreateSignalingChannelRequest_BadParams( void )
 /**
  * @brief Validate Signaling Construct Channel Request functionality.
  */
-void test_signaling_ConstructCreateSignalingChannelRequest_Url_OutofMemory( void )
+void test_signaling_ConstructCreateSignalingChannelRequest_UrlOutofMemory( void )
 {
     SignalingAwsRegion_t awsRegion = { 0 };
     CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
-    char urlBuffer[ 20 ];       /* URL Buffer small */
+    SignalingResult_t result;
+    char urlBuffer[ 20 ]; /* URL buffer too small to fit the complete URL. */
     char bodyBuffer[ 500 ];
-    SignalingResult_t result;
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -1244,7 +1256,8 @@ void test_signaling_ConstructCreateSignalingChannelRequest_Url_OutofMemory( void
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
-                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( createSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
                        result );
@@ -1255,14 +1268,14 @@ void test_signaling_ConstructCreateSignalingChannelRequest_Url_OutofMemory( void
 /**
  * @brief Validate Signaling Construct Channel Request functionality.
  */
-void test_signaling_ConstructCreateSignalingChannelRequest_Body_OutofMemory( void )
+void test_signaling_ConstructCreateSignalingChannelRequest_BodyOutofMemory( void )
 {
     SignalingAwsRegion_t awsRegion = { 0 };
     CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
-    char urlBuffer[ 200 ];
-    char bodyBuffer[ 100 ];     /* Body Buffer Small */
     SignalingResult_t result;
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 100 ]; /* Body buffer too small to fit the complete body. */
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -1280,7 +1293,8 @@ void test_signaling_ConstructCreateSignalingChannelRequest_Body_OutofMemory( voi
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
-                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( createSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
                        result );
@@ -1291,14 +1305,14 @@ void test_signaling_ConstructCreateSignalingChannelRequest_Body_OutofMemory( voi
 /**
  * @brief Validate Signaling Construct Channel Request functionality.
  */
-void test_signaling_ConstructCreateSignalingChannelRequest_Body_RightBracket_OutofMemory( void )
+void test_signaling_ConstructCreateSignalingChannelRequest_BodyClosingBraceOutofMemory( void )
 {
     SignalingAwsRegion_t awsRegion = { 0 };
     CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
-    char urlBuffer[ 200 ];
-    char bodyBuffer[ 113 ];                 /* Body Buffer in-capable of adding the "}" in the Body */
     SignalingResult_t result;
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 113 ]; /* Body buffer does not have space for the closing "}" in the body. */
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -1316,7 +1330,8 @@ void test_signaling_ConstructCreateSignalingChannelRequest_Body_RightBracket_Out
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
-                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( createSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
                        result );
@@ -1332,17 +1347,19 @@ void test_signaling_ConstructCreateSignalingChannelRequest( void )
     SignalingAwsRegion_t awsRegion = { 0 };
     CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
     char urlBuffer[ 200 ];
     char bodyBuffer[ 500 ];
-    SignalingResult_t result;
     const char * pExpectedUrl = "https://kinesisvideo.us-east-1.amazonaws.com/createSignalingChannel";
-    const char * pExpectedBody = "{"
-                                    "\"ChannelName\":\"Test-Channel\","
-                                    "\"ChannelType\":\"SINGLE_MASTER\","
-                                    "\"SingleMasterConfiguration\":{"
-                                        "\"MessageTtlSeconds\":60"
-                                    "}"
-                                  "}";
+    const char * pExpectedBody =
+    "{"
+        "\"ChannelName\":\"Test-Channel\","
+        "\"ChannelType\":\"SINGLE_MASTER\","
+        "\"SingleMasterConfiguration\":"
+        "{"
+            "\"MessageTtlSeconds\":60"
+        "}"
+    "}";
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -1360,18 +1377,21 @@ void test_signaling_ConstructCreateSignalingChannelRequest( void )
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
-                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( createSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
                        requestBuffer.urlLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
-                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
+                                  requestBuffer.pUrl,
+                                  requestBuffer.urlLength );
     TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
                        requestBuffer.bodyLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
-                              requestBuffer.pBody );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedBody,
+                                  requestBuffer.pBody,
+                                  requestBuffer.bodyLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -1379,22 +1399,24 @@ void test_signaling_ConstructCreateSignalingChannelRequest( void )
 /**
  * @brief Validate Signaling Construct Channel Request functionality.
  */
-void test_signaling_ConstructCreateSignalingChannelRequest_Unkown_ChannelType( void )
+void test_signaling_ConstructCreateSignalingChannelRequest_UnkownChannelType( void )
 {
     SignalingAwsRegion_t awsRegion = { 0 };
     CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
     char urlBuffer[ 200 ];
     char bodyBuffer[ 500 ];
-    SignalingResult_t result;
     const char * pExpectedUrl = "https://kinesisvideo.us-east-1.amazonaws.com/createSignalingChannel";
-    const char * pExpectedBody = "{"
-                                    "\"ChannelName\":\"Test-Channel\","
-                                    "\"ChannelType\":\"UNKOWN\","
-                                    "\"SingleMasterConfiguration\":{"
-                                        "\"MessageTtlSeconds\":60"
-                                    "}"
-                                  "}";
+    const char * pExpectedBody =
+    "{"
+        "\"ChannelName\":\"Test-Channel\","
+        "\"ChannelType\":\"UNKOWN\","
+        "\"SingleMasterConfiguration\":"
+        "{"
+            "\"MessageTtlSeconds\":60"
+        "}"
+    "}";
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -1412,18 +1434,21 @@ void test_signaling_ConstructCreateSignalingChannelRequest_Unkown_ChannelType( v
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
-                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( createSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
                        requestBuffer.urlLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
-                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
+                                  requestBuffer.pUrl,
+                                  requestBuffer.urlLength );
     TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
                        requestBuffer.bodyLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
-                              requestBuffer.pBody );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedBody,
+                                  requestBuffer.pBody,
+                                  requestBuffer.bodyLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -1436,19 +1461,21 @@ void test_signaling_ConstructCreateSignalingChannelRequest_SmallLengthRegion( vo
     SignalingAwsRegion_t awsRegion = { 0 };
     CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
     char urlBuffer[ 200 ];
     char bodyBuffer[ 500 ];
-    SignalingResult_t result;
     const char * pExpectedUrl = "https://kinesisvideo.ca.amazonaws.com/createSignalingChannel";
-    const char * pExpectedBody = "{"
-                                    "\"ChannelName\":\"Test-Channel\","
-                                    "\"ChannelType\":\"SINGLE_MASTER\","
-                                    "\"SingleMasterConfiguration\":{"
-                                        "\"MessageTtlSeconds\":60"
-                                    "}"
-                                  "}";
+    const char * pExpectedBody =
+    "{"
+        "\"ChannelName\":\"Test-Channel\","
+        "\"ChannelType\":\"SINGLE_MASTER\","
+        "\"SingleMasterConfiguration\":"
+        "{"
+            "\"MessageTtlSeconds\":60"
+        "}"
+    "}";
 
-    awsRegion.pAwsRegion = "ca";            /* The Region Length is < 3 */
+    awsRegion.pAwsRegion = "ca"; /* The Region Length is < 3. */
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
 
     createSignalingChannelRequestInfo.channelName.pChannelName = "Test-Channel";
@@ -1464,18 +1491,21 @@ void test_signaling_ConstructCreateSignalingChannelRequest_SmallLengthRegion( vo
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
-                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( createSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
                        requestBuffer.urlLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
-                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
+                                  requestBuffer.pUrl,
+                                  requestBuffer.urlLength );
     TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
                        requestBuffer.bodyLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
-                              requestBuffer.pBody );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedBody,
+                                  requestBuffer.pBody,
+                                  requestBuffer.bodyLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -1488,17 +1518,19 @@ void test_signaling_ConstructCreateSignalingChannelRequest_ChinaRegion( void )
     SignalingAwsRegion_t awsRegion = { 0 };
     CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
     char urlBuffer[ 200 ];
     char bodyBuffer[ 500 ];
-    SignalingResult_t result;
     const char * pExpectedUrl = "https://kinesisvideo.cn-north-1.amazonaws.com.cn/createSignalingChannel";
-    const char * pExpectedBody = "{"
-                                    "\"ChannelName\":\"Test-Channel\","
-                                    "\"ChannelType\":\"SINGLE_MASTER\","
-                                    "\"SingleMasterConfiguration\":{"
-                                        "\"MessageTtlSeconds\":60"
-                                    "}"
-                                  "}";
+    const char * pExpectedBody =
+    "{"
+        "\"ChannelName\":\"Test-Channel\","
+        "\"ChannelType\":\"SINGLE_MASTER\","
+        "\"SingleMasterConfiguration\":"
+        "{"
+            "\"MessageTtlSeconds\":60"
+        "}"
+    "}";
 
     awsRegion.pAwsRegion = "cn-north-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -1516,18 +1548,21 @@ void test_signaling_ConstructCreateSignalingChannelRequest_ChinaRegion( void )
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
-                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( createSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
                        requestBuffer.urlLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
-                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
+                                  requestBuffer.pUrl,
+                                  requestBuffer.urlLength );
     TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
                        requestBuffer.bodyLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
-                              requestBuffer.pBody );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedBody,
+                                  requestBuffer.pBody,
+                                  requestBuffer.bodyLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -1535,23 +1570,23 @@ void test_signaling_ConstructCreateSignalingChannelRequest_ChinaRegion( void )
 /**
  * @brief Validate Signaling Construct Channel Request functionality.
  */
-void test_signaling_ConstructCreateSignalingChannelRequest_WithTags_LeftArrayBracket_OutofMemory( void )
+void test_signaling_ConstructCreateSignalingChannelRequest_WithTagsLeftArrayBracketOutofMemory( void )
 {
     SignalingAwsRegion_t awsRegion = { 0 };
     CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
     SignalingTag_t tags[ 1 ] = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
-    char urlBuffer[ 200 ];
-    char bodyBuffer[ 121 ];         /* Buffer in-capable of adding "[" in the body */
     SignalingResult_t result;
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 121 ]; /* Buffer not large enough to contain "[" in the body. */
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
 
-    tags->pName = "Tag1";
-    tags->nameLength = strlen( tags->pName );
-    tags->pValue = "Value1";
-    tags->valueLength = strlen( tags->pValue );
+    tags[ 0 ].pName = "Tag1";
+    tags[ 0 ].nameLength = strlen( tags->pName );
+    tags[ 0 ].pValue = "Value1";
+    tags[ 0 ].valueLength = strlen( tags->pValue );
 
     createSignalingChannelRequestInfo.channelName.pChannelName = "Test-Channel";
     createSignalingChannelRequestInfo.channelName.channelNameLength = strlen( createSignalingChannelRequestInfo.channelName.pChannelName );
@@ -1566,7 +1601,8 @@ void test_signaling_ConstructCreateSignalingChannelRequest_WithTags_LeftArrayBra
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
-                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( createSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
                        result );
@@ -1577,15 +1613,15 @@ void test_signaling_ConstructCreateSignalingChannelRequest_WithTags_LeftArrayBra
 /**
  * @brief Validate Signaling Construct Channel Request functionality.
  */
-void test_signaling_ConstructCreateSignalingChannelRequest_WithTags_OutofMemory( void )
+void test_signaling_ConstructCreateSignalingChannelRequest_WithTagsOutofMemory( void )
 {
     SignalingAwsRegion_t awsRegion = { 0 };
     CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
     SignalingTag_t tags[ 2 ] = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
-    char urlBuffer[ 200 ];
-    char bodyBuffer[ 170 ];         /* Buffer in-capable of adding Tags in the body */
     SignalingResult_t result;
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 170 ]; /* Buffer not large enough to contain tags in the body. */
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -1613,7 +1649,8 @@ void test_signaling_ConstructCreateSignalingChannelRequest_WithTags_OutofMemory(
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
-                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( createSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
                        result );
@@ -1624,15 +1661,15 @@ void test_signaling_ConstructCreateSignalingChannelRequest_WithTags_OutofMemory(
 /**
  * @brief Validate Signaling Construct Channel Request functionality.
  */
-void test_signaling_ConstructCreateSignalingChannelRequest_WithTags_RightArrayBracket_OutofMemory( void )
+void test_signaling_ConstructCreateSignalingChannelRequest_WithTagsRightArrayBracketOutofMemory( void )
 {
     SignalingAwsRegion_t awsRegion = { 0 };
     CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
     SignalingTag_t tags[ 2 ] = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
-    char urlBuffer[ 200 ];
-    char bodyBuffer[ 185 ];         /* Buffer in-capable of adding "]" in the body */
     SignalingResult_t result;
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 185 ]; /* Buffer not large enough to contain "]" in the body. */
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -1660,7 +1697,8 @@ void test_signaling_ConstructCreateSignalingChannelRequest_WithTags_RightArrayBr
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
-                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( createSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
                        result );
@@ -1677,27 +1715,30 @@ void test_signaling_ConstructCreateSignalingChannelRequest_WithTags( void )
     CreateSignalingChannelRequestInfo_t createSignalingChannelRequestInfo = { 0 };
     SignalingTag_t tags[ 2 ] = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
     char urlBuffer[ 200 ];
     char bodyBuffer[ 500 ];
-    SignalingResult_t result;
     const char * pExpectedUrl = "https://kinesisvideo.us-east-1.amazonaws.com/createSignalingChannel";
-    const char * pExpectedBody = "{"
-                                    "\"ChannelName\":\"Test-Channel\","
-                                    "\"ChannelType\":\"SINGLE_MASTER\","
-                                    "\"SingleMasterConfiguration\":{"
-                                        "\"MessageTtlSeconds\":60"
-                                    "},"
-                                    "\"Tags\":["
-                                        "{"
-                                            "\"Key\":\"Tag1\","
-                                            "\"Value\":\"Value1\""
-                                        "},"
-                                        "{"
-                                            "\"Key\":\"Tag2\","
-                                            "\"Value\":\"Value2\""
-                                        "}"
-                                    "]"
-                                  "}";
+    const char * pExpectedBody =
+    "{"
+        "\"ChannelName\":\"Test-Channel\","
+        "\"ChannelType\":\"SINGLE_MASTER\","
+        "\"SingleMasterConfiguration\":"
+        "{"
+            "\"MessageTtlSeconds\":60"
+        "},"
+        "\"Tags\":"
+        "["
+            "{"
+                "\"Key\":\"Tag1\","
+                "\"Value\":\"Value1\""
+            "},"
+            "{"
+                "\"Key\":\"Tag2\","
+                "\"Value\":\"Value2\""
+            "}"
+        "]"
+    "}";
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -1725,18 +1766,21 @@ void test_signaling_ConstructCreateSignalingChannelRequest_WithTags( void )
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructCreateSignalingChannelRequest( &( awsRegion ),
-                                                               &( createSignalingChannelRequestInfo ), &( requestBuffer ) );
+                                                               &( createSignalingChannelRequestInfo ),
+                                                               &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
                        requestBuffer.urlLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
-                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
+                                  requestBuffer.pUrl,
+                                  requestBuffer.urlLength );
     TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
                        requestBuffer.bodyLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
-                              requestBuffer.pBody );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedBody,
+                                  requestBuffer.pBody,
+                                  requestBuffer.bodyLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -1746,19 +1790,21 @@ void test_signaling_ConstructCreateSignalingChannelRequest_WithTags( void )
  */
 void test_signaling_ParseCreateSignalingChannelResponse_BadParams( void )
 {
-    const char * message = "Valid-Message";
-    size_t messageLength = strlen( message );
     SignalingChannelArn_t channelArn = { 0 };
     SignalingResult_t result;
+    const char * message = "Valid-Message";
+    size_t messageLength = strlen( message );
 
     result = Signaling_ParseCreateSignalingChannelResponse( NULL,
-                                                            messageLength, &( channelArn ) );
+                                                            messageLength,
+                                                            &( channelArn ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     result = Signaling_ParseCreateSignalingChannelResponse( message,
-                                                            messageLength, NULL );
+                                                            messageLength,
+                                                            NULL );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -1771,13 +1817,14 @@ void test_signaling_ParseCreateSignalingChannelResponse_BadParams( void )
  */
 void test_signaling_ParseCreateSignalingChannelResponse_InvalidJson( void )
 {
-    const char * message = "{\"ChannelARN\": \"test-arn\"";  /* Missing closing brace */
-    size_t messageLength = strlen( message );
     SignalingChannelArn_t channelArn = { 0 };
     SignalingResult_t result;
+    const char * message = "{\"ChannelARN\": \"test-arn\"";  /* Missing closing brace. */
+    size_t messageLength = strlen( message );
 
     result = Signaling_ParseCreateSignalingChannelResponse( message,
-                                                            messageLength, &( channelArn ) );
+                                                            messageLength,
+                                                            &( channelArn ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
                        result );
@@ -1790,13 +1837,14 @@ void test_signaling_ParseCreateSignalingChannelResponse_InvalidJson( void )
  */
 void test_signaling_ParseCreateSignalingChannelResponse_UnexpectedResponse( void )
 {
-    const char * message = "{}";
-    size_t messageLength = strlen( message );
     SignalingChannelArn_t channelArn = { 0 };
     SignalingResult_t result;
+    const char * message = "{}";
+    size_t messageLength = strlen( message );
 
     result = Signaling_ParseCreateSignalingChannelResponse( message,
-                                                            messageLength, &( channelArn ) );
+                                                            messageLength,
+                                                            &( channelArn ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
@@ -1807,22 +1855,22 @@ void test_signaling_ParseCreateSignalingChannelResponse_UnexpectedResponse( void
 /**
  * @brief Validate Signaling Parse Create Signaling Channel Response functionality.
  */
-void test_signaling_ParseCreateSignalingChannelResponse_Unkown( void )
+void test_signaling_ParseCreateSignalingChannelResponse_UnkownKey( void )
 {
-    const char * message = "{"
-        "\"Unkown\": \"arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123\""        /* Unkown is ignored */
-    "}";
-    size_t messageLength = strlen( message );
     SignalingChannelArn_t channelArn = { 0 };
     SignalingResult_t result;
+    const char * message =
+    "{"
+        "\"Unkown\": \"arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123\""
+    "}";
+    size_t messageLength = strlen( message );
 
     result = Signaling_ParseCreateSignalingChannelResponse( message,
-                                                            messageLength, &( channelArn ) );
+                                                            messageLength,
+                                                            &( channelArn ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
-    TEST_ASSERT_EQUAL( 0, channelArn.pChannelArn );
-    TEST_ASSERT_EQUAL( 0, channelArn.channelArnLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -1834,18 +1882,21 @@ void test_signaling_ParseCreateSignalingChannelResponse( void )
 {
     SignalingChannelArn_t channelArn = { 0 };
     SignalingResult_t result;
-    const char *message = "{"
+    const char *message =
+    "{"
         "\"ChannelARN\": \"arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123\""
     "}";
     size_t messageLength = strlen( message );
     const char * pExpectedChannelArn = "arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123";
 
     result = Signaling_ParseCreateSignalingChannelResponse( message,
-                                                            messageLength, &( channelArn ) );
+                                                            messageLength,
+                                                            &( channelArn ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
-    TEST_ASSERT_EQUAL( strlen( pExpectedChannelArn ), channelArn.channelArnLength );
+    TEST_ASSERT_EQUAL( strlen( pExpectedChannelArn ),
+                       channelArn.channelArnLength );
     TEST_ASSERT_EQUAL_STRING_LEN( pExpectedChannelArn,
                                   channelArn.pChannelArn,
                                   channelArn.channelArnLength );
@@ -1861,11 +1912,12 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_BadParams( void 
     SignalingAwsRegion_t awsRegion = { 0 };
     GetSignalingChannelEndpointRequestInfo_t getSignalingChannelEndPointRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
-    const char * channelArn = "arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123";
     SignalingResult_t result;
+    const char * channelArn = "arn:aws:kinesisvideo:us-west-2:123456789012:channel/test-channel/1234567890123";
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( NULL,
-                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+                                                                    &( getSignalingChannelEndPointRequestInfo ),
+                                                                    &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -1873,7 +1925,8 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_BadParams( void 
     awsRegion.pAwsRegion = NULL;
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
-                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+                                                                    &( getSignalingChannelEndPointRequestInfo ),
+                                                                    &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -1882,13 +1935,15 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_BadParams( void 
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
-                                                                    &( getSignalingChannelEndPointRequestInfo ), NULL );
+                                                                    &( getSignalingChannelEndPointRequestInfo ),
+                                                                    NULL );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
-                                                                    NULL, &( requestBuffer ) );
+                                                                    NULL,
+                                                                    &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -1896,7 +1951,8 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_BadParams( void 
     requestBuffer.pUrl = NULL;
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
-                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+                                                                    &( getSignalingChannelEndPointRequestInfo ),
+                                                                    &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -1906,7 +1962,8 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_BadParams( void 
     requestBuffer.pBody = NULL;
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
-                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+                                                                    &( getSignalingChannelEndPointRequestInfo ),
+                                                                    &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -1916,7 +1973,8 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_BadParams( void 
     getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn = NULL;
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
-                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+                                                                    &( getSignalingChannelEndPointRequestInfo ),
+                                                                    &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -1926,7 +1984,8 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_BadParams( void 
     getSignalingChannelEndPointRequestInfo.role = SIGNALING_ROLE_NONE;
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
-                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+                                                                    &( getSignalingChannelEndPointRequestInfo ),
+                                                                    &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -1937,14 +1996,14 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_BadParams( void 
 /**
  * @brief Validate Signaling Construct Get Channel Endpoint Request functionality .
  */
-void test_signaling_ConstructGetSignalingChannelEndpointRequest_URL_OutofMemory( void )
+void test_signaling_ConstructGetSignalingChannelEndpointRequest_UrlOutofMemory( void )
 {
     SignalingAwsRegion_t awsRegion = { 0 };
     GetSignalingChannelEndpointRequestInfo_t getSignalingChannelEndPointRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
-    char urlBuffer[ 72 ];           /* Small URL Buffer */
-    char bodyBuffer[ 500 ];
     SignalingResult_t result;
+    char urlBuffer[ 72 ]; /* Buffer too small to fit the complete URL. */
+    char bodyBuffer[ 500 ];
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -1960,7 +2019,8 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_URL_OutofMemory(
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
-                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+                                                                    &( getSignalingChannelEndPointRequestInfo ),
+                                                                    &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
                        result );
@@ -1971,14 +2031,14 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_URL_OutofMemory(
 /**
  * @brief Validate Signaling Construct Get Channel Endpoint Request functionality .
  */
-void test_signaling_ConstructGetSignalingChannelEndpointRequest_Body_OutofMemory( void )
+void test_signaling_ConstructGetSignalingChannelEndpointRequest_BodyOutofMemory( void )
 {
     SignalingAwsRegion_t awsRegion = { 0 };
     GetSignalingChannelEndpointRequestInfo_t getSignalingChannelEndPointRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
-    char urlBuffer[ 200 ];
-    char bodyBuffer[ 184 ];         /* Small Body Buffer */
     SignalingResult_t result;
+    char urlBuffer[ 200 ];
+    char bodyBuffer[ 184 ]; /* Body buffer too small to fit the complete body. */
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -1994,7 +2054,8 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_Body_OutofMemory
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
-                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+                                                                    &( getSignalingChannelEndPointRequestInfo ),
+                                                                    &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
                        result );
@@ -2005,22 +2066,24 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_Body_OutofMemory
 /**
  * @brief Validate Signaling Construct Get Channel Endpoint Request functionality .
  */
-void test_signaling_ConstructGetSignalingChannelEndpointRequest_HTTP( void )
+void test_signaling_ConstructGetSignalingChannelEndpointRequest_Https( void )
 {
     SignalingAwsRegion_t awsRegion = { 0 };
     GetSignalingChannelEndpointRequestInfo_t getSignalingChannelEndPointRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
     char urlBuffer[ 200 ];
     char bodyBuffer[ 500 ];
-    SignalingResult_t result;
     const char * pExpectedUrl = "https://kinesisvideo.us-east-1.amazonaws.com/getSignalingChannelEndpoint";
-    const char * pExpectedBody = "{"
-                                    "\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\","
-                                    "\"SingleMasterChannelEndpointConfiguration\":{"
-                                        "\"Protocols\":[\"HTTPS\"],"
-                                        "\"Role\":\"MASTER\""
-                                    "}"
-                                  "}";
+    const char * pExpectedBody =
+    "{"
+        "\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\","
+        "\"SingleMasterChannelEndpointConfiguration\":"
+        "{"
+            "\"Protocols\":[\"HTTPS\"],"
+            "\"Role\":\"MASTER\""
+        "}"
+    "}";
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -2036,18 +2099,21 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_HTTP( void )
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
-                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+                                                                    &( getSignalingChannelEndPointRequestInfo ),
+                                                                    &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
                        requestBuffer.urlLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
-                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
+                                  requestBuffer.pUrl,
+                                  requestBuffer.urlLength );
     TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
                        requestBuffer.bodyLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
-                              requestBuffer.pBody );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedBody,
+                                  requestBuffer.pBody,
+                                  requestBuffer.bodyLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -2060,17 +2126,19 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_ChinaRegion( voi
     SignalingAwsRegion_t awsRegion = { 0 };
     GetSignalingChannelEndpointRequestInfo_t getSignalingChannelEndPointRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
     char urlBuffer[ 200 ];
     char bodyBuffer[ 500 ];
-    SignalingResult_t result;
     const char * pExpectedUrl = "https://kinesisvideo.cn-east-1.amazonaws.com.cn/getSignalingChannelEndpoint";
-    const char * pExpectedBody = "{"
-                                    "\"ChannelARN\":\"arn:aws-cn:kinesisvideo:cn-east-1:123456789012:channel/test-channel/1234567890123\","
-                                    "\"SingleMasterChannelEndpointConfiguration\":{"
-                                        "\"Protocols\":[\"WSS\",\"HTTPS\"],"
-                                        "\"Role\":\"VIEWER\""
-                                    "}"
-                                  "}";
+    const char * pExpectedBody =
+    "{"
+        "\"ChannelARN\":\"arn:aws-cn:kinesisvideo:cn-east-1:123456789012:channel/test-channel/1234567890123\","
+        "\"SingleMasterChannelEndpointConfiguration\":"
+        "{"
+            "\"Protocols\":[\"WSS\",\"HTTPS\"],"
+            "\"Role\":\"VIEWER\""
+        "}"
+    "}";
 
     awsRegion.pAwsRegion = "cn-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -2086,18 +2154,21 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_ChinaRegion( voi
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
-                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+                                                                    &( getSignalingChannelEndPointRequestInfo ),
+                                                                    &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
                        requestBuffer.urlLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
-                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
+                                  requestBuffer.pUrl,
+                                  requestBuffer.urlLength );
     TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
                        requestBuffer.bodyLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
-                              requestBuffer.pBody );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedBody,
+                                  requestBuffer.pBody,
+                                  requestBuffer.bodyLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -2110,19 +2181,21 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_SmallLengthRegio
     SignalingAwsRegion_t awsRegion = { 0 };
     GetSignalingChannelEndpointRequestInfo_t getSignalingChannelEndPointRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
     char urlBuffer[ 200 ];
     char bodyBuffer[ 500 ];
-    SignalingResult_t result;
     const char * pExpectedUrl = "https://kinesisvideo.ca.amazonaws.com/getSignalingChannelEndpoint";
-    const char * pExpectedBody = "{"
-                                    "\"ChannelARN\":\"arn:aws:kinesisvideo:ca:123456789012:channel/test-channel/1234567890123\","
-                                    "\"SingleMasterChannelEndpointConfiguration\":{"
-                                        "\"Protocols\":[\"WSS\",\"HTTPS\"],"
-                                        "\"Role\":\"MASTER\""
-                                    "}"
-                                  "}";
+    const char * pExpectedBody =
+    "{"
+        "\"ChannelARN\":\"arn:aws:kinesisvideo:ca:123456789012:channel/test-channel/1234567890123\","
+        "\"SingleMasterChannelEndpointConfiguration\":"
+        "{"
+            "\"Protocols\":[\"WSS\",\"HTTPS\"],"
+            "\"Role\":\"MASTER\""
+        "}"
+    "}";
 
-    awsRegion.pAwsRegion = "ca";                /* The Region Length is < 3 */
+    awsRegion.pAwsRegion = "ca"; /* The Region Length is < 3. */
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
 
     getSignalingChannelEndPointRequestInfo.channelArn.pChannelArn = "arn:aws:kinesisvideo:ca:123456789012:channel/test-channel/1234567890123";
@@ -2136,18 +2209,21 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_SmallLengthRegio
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
-                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+                                                                    &( getSignalingChannelEndPointRequestInfo ),
+                                                                    &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
                        requestBuffer.urlLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
-                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
+                                  requestBuffer.pUrl,
+                                  requestBuffer.urlLength );
     TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
                        requestBuffer.bodyLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
-                              requestBuffer.pBody );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedBody,
+                                  requestBuffer.pBody,
+                                  requestBuffer.bodyLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -2155,22 +2231,24 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_SmallLengthRegio
 /**
  * @brief Validate Signaling Construct Get Channel Endpoint Request functionality .
  */
-void test_signaling_ConstructGetSignalingChannelEndpointRequest_WebSockets_Or_WebRTC( void )
+void test_signaling_ConstructGetSignalingChannelEndpointRequest_WebSocketsOrWebRtc( void )
 {
     SignalingAwsRegion_t awsRegion = { 0 };
     GetSignalingChannelEndpointRequestInfo_t getSignalingChannelEndPointRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
     char urlBuffer[ 200 ];
     char bodyBuffer[ 500 ];
-    SignalingResult_t result;
     const char * pExpectedUrl = "https://kinesisvideo.us-east-1.amazonaws.com/getSignalingChannelEndpoint";
-    const char * pExpectedBody = "{"
-                                    "\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\","
-                                    "\"SingleMasterChannelEndpointConfiguration\":{"
-                                        "\"Protocols\":[\"WSS\",\"WEBRTC\"],"
-                                        "\"Role\":\"MASTER\""
-                                    "}"
-                                  "}";
+    const char * pExpectedBody =
+    "{"
+        "\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\","
+        "\"SingleMasterChannelEndpointConfiguration\":"
+        "{"
+            "\"Protocols\":[\"WSS\",\"WEBRTC\"],"
+            "\"Role\":\"MASTER\""
+        "}"
+    "}";
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -2186,18 +2264,21 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_WebSockets_Or_We
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
-                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+                                                                    &( getSignalingChannelEndPointRequestInfo ),
+                                                                    &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
                        requestBuffer.urlLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
-                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
+                                  requestBuffer.pUrl,
+                                  requestBuffer.urlLength );
     TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
                        requestBuffer.bodyLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
-                              requestBuffer.pBody );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedBody,
+                                  requestBuffer.pBody,
+                                  requestBuffer.bodyLength );
 }
 
 /*-----------------------------------------------------------*/
@@ -2205,22 +2286,24 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_WebSockets_Or_We
 /**
  * @brief Validate Signaling Construct Get Channel Endpoint Request functionality .
  */
-void test_signaling_ConstructGetSignalingChannelEndpointRequest_WebRTC( void )
+void test_signaling_ConstructGetSignalingChannelEndpointRequest_WebRtc( void )
 {
     SignalingAwsRegion_t awsRegion = { 0 };
     GetSignalingChannelEndpointRequestInfo_t getSignalingChannelEndPointRequestInfo = { 0 };
     SignalingRequest_t requestBuffer = { 0 };
+    SignalingResult_t result;
     char urlBuffer[ 200 ];
     char bodyBuffer[ 500 ];
-    SignalingResult_t result;
     const char * pExpectedUrl = "https://kinesisvideo.us-east-1.amazonaws.com/getSignalingChannelEndpoint";
-    const char * pExpectedBody = "{"
-                                    "\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\","
-                                    "\"SingleMasterChannelEndpointConfiguration\":{"
-                                        "\"Protocols\":[\"WEBRTC\"],"
-                                        "\"Role\":\"MASTER\""
-                                    "}"
-                                  "}";
+    const char * pExpectedBody =
+    "{"
+        "\"ChannelARN\":\"arn:aws:kinesisvideo:us-east-1:123456789012:channel/test-channel/1234567890123\","
+        "\"SingleMasterChannelEndpointConfiguration\":"
+        "{"
+            "\"Protocols\":[\"WEBRTC\"],"
+            "\"Role\":\"MASTER\""
+        "}"
+    "}";
 
     awsRegion.pAwsRegion = "us-east-1";
     awsRegion.awsRegionLength = strlen( awsRegion.pAwsRegion );
@@ -2236,18 +2319,21 @@ void test_signaling_ConstructGetSignalingChannelEndpointRequest_WebRTC( void )
     requestBuffer.bodyLength = sizeof( bodyBuffer );
 
     result = Signaling_ConstructGetSignalingChannelEndpointRequest( &( awsRegion ),
-                                                                    &( getSignalingChannelEndPointRequestInfo ), &( requestBuffer ) );
+                                                                    &( getSignalingChannelEndPointRequestInfo ),
+                                                                    &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
     TEST_ASSERT_EQUAL( strlen( pExpectedUrl ),
                        requestBuffer.urlLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedUrl,
-                              requestBuffer.pUrl );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedUrl,
+                                  requestBuffer.pUrl,
+                                  requestBuffer.urlLength );
     TEST_ASSERT_EQUAL( strlen( pExpectedBody ),
                        requestBuffer.bodyLength );
-    TEST_ASSERT_EQUAL_STRING( pExpectedBody,
-                              requestBuffer.pBody );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedBody,
+                                  requestBuffer.pBody,
+                                  requestBuffer.bodyLength );
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
### Description of changes:

This PR is for improving bugs in the source code and adding additional unit tests to improve coverage, by thoroughly testing various Signaling API's .

The following test cases have been added:
1. `test_signaling_ConstructDescribeSignalingChannelRequest`
2. `test_signaling_ConstructDescribeSignalingChannelRequest_SmallLengthRegion`
3.  `test_signaling_ConstructDescribeSignalingChannelRequest_ChinaRegion`
4.  `test_signaling_ConstructDescribeSignalingChannelRequest_URLOutofMemory`
5.  `test_signaling_ConstructDescribeSignalingChannelRequest_BodyOutofMemory`
6.  `test_signaling_ParseDescribeSignalingChannelResponse_BadParams`
7.  `test_signaling_ParseDescribeSignalingChannelResponse_InvalidJson`
8. `test_signaling_ParseDescribeSignalingChannelResponse_UnexpectedResponse`
9. `test_signaling_ParseDescribeSignalingChannelResponse_InvalidTTL_Low`
10. `test_signaling_ParseDescribeSignalingChannelResponse_InvalidTTL_High`
11. `test_signaling_ParseDescribeSignalingChannelResponse_InvalidChannel_Type`
12. `test_signaling_ParseDescribeSignalingChannelResponse_InvalidChannel_Name`
13. `test_signaling_ParseDescribeSignalingChannelResponse`
14. `test_signaling_ConstructDescribeMediaStorageConfigRequest_BadParams`
15. `test_signaling_ConstructDescribeMediaStorageConfigRequest`
16. `test_signaling_ConstructDescribeMediaStorageConfigRequest_SmallLengthRegion`
17. `test_signaling_ConstructDescribeMediaStorageConfigRequest_ChinaRegion`
18. `test_signaling_ConstructDescribeMediaStorageConfigRequest_URLOutOfMemory`
19. `test_signaling_ConstructDescribeMediaStorageConfigRequest_BodyOutOfMemory`
20. `test_signaling_ParseDescribeMediaStorageConfigResponse_BadParams`
21. `test_signaling_ParseDescribeMediaStorageConfigResponse_InvalidJson`
22. `test_signaling_ParseDescribeMediaStorageConfigResponse_UnexpectedResponse`
23. `test_signaling_ParseDescribeMediaStorageConfigResponse_MissingFields`
24. `test_signaling_ParseDescribeMediaStorageConfigResponse`
25. `test_signaling_ConstructCreateSignalingChannelRequest_BadParams`
26. `test_signaling_ConstructCreateSignalingChannelRequest`
27. `test_signaling_ConstructCreateSignalingChannelRequest_SmallLengthRegion`
28. `test_signaling_ConstructCreateSignalingChannelRequest_ChinaRegion`
29. `test_signaling_ConstructCreateSignalingChannelRequest_WithTags`
30. `test_signaling_ParseCreateSignalingChannelResponse_BadParams`
31. `test_signaling_ParseCreateSignalingChannelResponse_InvalidJson`
32. `test_signaling_ParseCreateSignalingChannelResponse_UnexpectedResponse`
33. `test_signaling_ParseCreateSignalingChannelResponse`
34. `test_signaling_ConstructGetSignalingChannelEndpointRequest_BadParams`
35. `test_signaling_ConstructGetSignalingChannelEndpointRequest`


### Test Steps

```
cmake -S test/unit-test -B build/ -G "Unix Makefiles"  -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
make -C build all
cd build
ctest -E system --output-on-failure
make coverage
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
