### PR TITLE
Added Session Token Credential Request & Response and its Unit Tests

### DIFF
--- a/source/include/signaling_api.h
+++ b/source/include/signaling_api.h
@@ -76,6 +76,43 @@ SignalingResult_t Signaling_ConstructDescribeMediaStorageConfigRequest( Signalin
                                                                         SignalingRequest_t * pRequestBuffer );
 
 /**
+ * @brief This function is used to construct request to query the Session Token Temporary Credentials.
+ *
+ * @param[in] pEndpoint The AWS Endpoint.
+ * @param[in] pRoleAlias The Role Alias associated with the Role that is used to authentication.
+ * @param[out] pRequestBuffer The output structure includes URI, body buffers, and their sizes.
+ *
+ * @return Returns one of the following:
+ * - #SIGNALING_RESULT_OK, if initialization was performed without error.
+ * - #SIGNALING_RESULT_BAD_PARAM, if any mandatory parameters is NULL.
+ * - #SIGNALING_RESULT_SNPRINTF_ERROR, if snprintf returns negative value.
+ * - #SIGNALING_RESULT_OUT_OF_MEMORY, if buffer is not enough to store constructed message.
+ *
+ * @note Refer to https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/how-iot.html for details.
+ */
+SignalingResult_t Signaling_ConstructSessionTokenCredentialsRequest(  char * pEndpoint, char * pRoleAlias, 
+                                                                      SignalingRequest_t * pRequestBuffer );
+
+/**
+ * @brief This function is used to parse response of describe media storage configurations.
+ *
+ * @param[in] pMessage Raw response from the URL of getting signaling channel endpoints.
+ * @param[in] messageLength Length of raw message.
+ * @param[out] pCredentials The output structure includes accessKey, SecretAccessKey, SessionToken, Expiration.
+ *
+ * @return Returns one of the following:
+ * - #SIGNALING_RESULT_OK, if initialization was performed without error.
+ * - #SIGNALING_RESULT_BAD_PARAM, if any mandatory parameters is NULL.
+ * - #SIGNALING_RESULT_INVALID_JSON, if raw message is not a valid JSON message.
+ * - #SIGNALING_RESULT_UNEXPECTED_RESPONSE, if the message isn't the expected one.
+ *
+ * @note Refer to https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/how-iot.html for details.
+ */
+SignalingResult_t Signaling_ParseSessionTokenCredentialsResponse( const char * pMessage,
+                                                                   size_t messageLength,
+                                                                    SignalingCredential_t *pCredentials);
+
+/**
  * @brief This function is used to parse response of describe media storage configurations.
  *
  * @param[in] pMessage Raw response from the URL of getting signaling channel endpoints.
@@ -106,6 +143,10 @@ SignalingResult_t Signaling_ParseDescribeMediaStorageConfigResponse( const char 
  * - #SIGNALING_RESULT_BAD_PARAM, if any mandatory parameters is NULL.
  * - #SIGNALING_RESULT_SNPRINTF_ERROR, if snprintf returns negative value.
  * - #SIGNALING_RESULT_OUT_OF_MEMORY, if buffer is not enough to store constructed message.
+ * - #SIGNALING_RESULT_ACCESS_KEY_LENGTH_TOO_LARGE, if accessKey overflows.
+ * - #SIGNALING_RESULT_SECRET_ACCESS_KEY_LENGTH_TOO_LARGE, if secret acessKey overflows.
+ * - #SIGNALING_RESULT_SESSION_TOKEN_LENGTH_TOO_LARGE, if session Token overflows.
+ * - #SIGNALING_RESULT_EXPIRATION_LENGTH_TOO_LARGE, if expiration overflows.
  *
  * @note Refer to https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_CreateSignalingChannel.html for details.
  */

--- a/source/include/signaling_api.h
+++ b/source/include/signaling_api.h
@@ -90,9 +90,11 @@ SignalingResult_t Signaling_ConstructDescribeMediaStorageConfigRequest( Signalin
  *
  * @note Refer to https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/how-iot.html for details.
  */
-SignalingResult_t Signaling_ConstructFetchTemporaryCredentialRequest(  const char * pEndpoint, size_t endpointLength,
-                                                                       const char * pRoleAlias, size_t roleAliasLength, 
-                                                                       SignalingRequest_t * pRequestBuffer );
+SignalingResult_t Signaling_ConstructFetchTemporaryCredentialRequest( const char * pEndpoint,
+                                                                      size_t endpointLength,
+                                                                      const char * pRoleAlias,
+                                                                      size_t roleAliasLength,
+                                                                      SignalingRequest_t * pRequestBuffer );
 
 /**
  * @brief This function is used to parse response of describe media storage configurations.
@@ -110,8 +112,8 @@ SignalingResult_t Signaling_ConstructFetchTemporaryCredentialRequest(  const cha
  * @note Refer to https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/how-iot.html for details.
  */
 SignalingResult_t Signaling_ParseFetchTemporaryCredentialsResponse( const char * pMessage,
-                                                                   size_t messageLength,
-                                                                    SignalingCredential_t *pCredentials);
+                                                                    size_t messageLength,
+                                                                    SignalingCredential_t * pCredentials );
 
 /**
  * @brief This function is used to parse response of describe media storage configurations.

--- a/source/include/signaling_api.h
+++ b/source/include/signaling_api.h
@@ -109,7 +109,7 @@ SignalingResult_t Signaling_ConstructFetchTemporaryCredentialRequest(  const cha
  *
  * @note Refer to https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/how-iot.html for details.
  */
-SignalingResult_t Signaling_ParseTemporaryCredentialsResponse( const char * pMessage,
+SignalingResult_t Signaling_ParseFetchTemporaryCredentialsResponse( const char * pMessage,
                                                                    size_t messageLength,
                                                                     SignalingCredential_t *pCredentials);
 

--- a/source/include/signaling_api.h
+++ b/source/include/signaling_api.h
@@ -90,8 +90,9 @@ SignalingResult_t Signaling_ConstructDescribeMediaStorageConfigRequest( Signalin
  *
  * @note Refer to https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/how-iot.html for details.
  */
-SignalingResult_t Signaling_ConstructSessionTokenCredentialsRequest(  char * pEndpoint, char * pRoleAlias, 
-                                                                      SignalingRequest_t * pRequestBuffer );
+SignalingResult_t Signaling_ConstructFetchTemporaryCredentialRequest(  const char * pEndpoint, size_t endpointLength,
+                                                                       const char * pRoleAlias, size_t roleAliasLength, 
+                                                                       SignalingRequest_t * pRequestBuffer );
 
 /**
  * @brief This function is used to parse response of describe media storage configurations.
@@ -108,7 +109,7 @@ SignalingResult_t Signaling_ConstructSessionTokenCredentialsRequest(  char * pEn
  *
  * @note Refer to https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/how-iot.html for details.
  */
-SignalingResult_t Signaling_ParseSessionTokenCredentialsResponse( const char * pMessage,
+SignalingResult_t Signaling_ParseTemporaryCredentialsResponse( const char * pMessage,
                                                                    size_t messageLength,
                                                                     SignalingCredential_t *pCredentials);
 

--- a/source/include/signaling_api.h
+++ b/source/include/signaling_api.h
@@ -76,10 +76,11 @@ SignalingResult_t Signaling_ConstructDescribeMediaStorageConfigRequest( Signalin
                                                                         SignalingRequest_t * pRequestBuffer );
 
 /**
- * @brief This function is used to construct request to query the Session Token Temporary Credentials.
+ * @brief This function is used to construct request to obtain Temporary Credentials
+ *        from AWS IoT Credential Provider.
  *
- * @param[in] pEndpoint The AWS Endpoint.
- * @param[in] pRoleAlias The Role Alias associated with the Role that is used to authentication.
+ * @param[in] pAwsIotEndpoint The AWS IoT Endpoint.
+ * @param[in] pRoleAlias The Role Alias associated with the Role that is used for authorization.
  * @param[out] pRequestBuffer The output structure includes URI, body buffers, and their sizes.
  *
  * @return Returns one of the following:
@@ -90,30 +91,34 @@ SignalingResult_t Signaling_ConstructDescribeMediaStorageConfigRequest( Signalin
  *
  * @note Refer to https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/how-iot.html for details.
  */
-SignalingResult_t Signaling_ConstructFetchTemporaryCredentialRequest( const char * pEndpoint,
-                                                                      size_t endpointLength,
-                                                                      const char * pRoleAlias,
-                                                                      size_t roleAliasLength,
-                                                                      SignalingRequest_t * pRequestBuffer );
+SignalingResult_t Signaling_ConstructFetchTempCredsRequestForAwsIot( const char * pAwsIotEndpoint,
+                                                                     size_t awsIotEndpointLength,
+                                                                     const char * pRoleAlias,
+                                                                     size_t roleAliasLength,
+                                                                     SignalingRequest_t * pRequestBuffer );
 
 /**
- * @brief This function is used to parse response of describe media storage configurations.
+ * @brief This function is used to parse AWS IoT Credential Provider response.
  *
- * @param[in] pMessage Raw response from the URL of getting signaling channel endpoints.
- * @param[in] messageLength Length of raw message.
- * @param[out] pCredentials The output structure includes accessKey, SecretAccessKey, SessionToken, Expiration.
+ * @param[in] pMessage Raw response from the AWS IoT Credential Provider.
+ * @param[in] messageLength Length of raw response.
+ * @param[out] pCredentials The output structure includes AccessKey, SecretAccessKey, SessionToken, Expiration.
  *
  * @return Returns one of the following:
  * - #SIGNALING_RESULT_OK, if initialization was performed without error.
  * - #SIGNALING_RESULT_BAD_PARAM, if any mandatory parameters is NULL.
  * - #SIGNALING_RESULT_INVALID_JSON, if raw message is not a valid JSON message.
  * - #SIGNALING_RESULT_UNEXPECTED_RESPONSE, if the message isn't the expected one.
+ * - #SIGNALING_RESULT_ACCESS_KEY_LENGTH_TOO_LARGE, if the access key is too large.
+ * - #SIGNALING_RESULT_SECRET_ACCESS_KEY_LENGTH_TOO_LARGE, if the secret access key is too large.
+ * - #SIGNALING_RESULT_SESSION_TOKEN_LENGTH_TOO_LARGE, if the session token is too large.
+ * - #SIGNALING_RESULT_EXPIRATION_LENGTH_TOO_LARGE, the expiration is too large.
  *
  * @note Refer to https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/how-iot.html for details.
  */
-SignalingResult_t Signaling_ParseFetchTemporaryCredentialsResponse( const char * pMessage,
-                                                                    size_t messageLength,
-                                                                    SignalingCredential_t * pCredentials );
+SignalingResult_t Signaling_ParseFetchTempCredsResponseFromAwsIot( const char * pMessage,
+                                                                   size_t messageLength,
+                                                                   SignalingCredential_t * pCredentials );
 
 /**
  * @brief This function is used to parse response of describe media storage configurations.

--- a/source/include/signaling_data_types.h
+++ b/source/include/signaling_data_types.h
@@ -197,10 +197,10 @@ typedef struct SignalingCredential
     const char* pSecretAccessKey;
     size_t secretAccessKeyLength;
 
-    const char* sessionToken;
+    const char* pSessionToken;
     size_t sessionTokenLength;
 
-    const char* expiration;
+    const char* pExpiration;
     size_t expirationLength;
 
 } SignalingCredential_t;

--- a/source/include/signaling_data_types.h
+++ b/source/include/signaling_data_types.h
@@ -191,7 +191,6 @@ typedef struct SignalingChannelArn
  */
 typedef struct SignalingCredential
 {
-
     const char* pAccessKeyId;
     size_t accessKeyIdLength;
 

--- a/source/include/signaling_data_types.h
+++ b/source/include/signaling_data_types.h
@@ -20,22 +20,22 @@
 /**
  * Maximum length of a Access Key.
  */
-#define MAX_ACCESS_KEY_LEN ( 128 )
+#define ACCESS_KEY_MAX_LEN ( 128 )
 
 /**
  * Maximum length of a Secret Access Key.
  */
-#define MAX_SECRET_KEY_LEN ( 128 )
+#define SECRET_ACCESS_KEY_MAX_LEN ( 128 )
 
 /**
  * Maximum length of a Session Token.
  */
-#define MAX_SESSION_TOKEN_LEN ( 2048 ) 
+#define SESSION_TOKEN_MAX_LEN ( 2048 )
 
 /**
  * Maximum length of a Expiration.
  */
-#define MAX_EXPIRATION_LEN ( 128 )  
+#define EXPIRATION_MAX_LEN ( 128 )
 
 /*-----------------------------------------------------------*/
 
@@ -187,22 +187,21 @@ typedef struct SignalingChannelArn
 
 /**
  * @ingroup signaling_enum_types
- * @brief Basic format of the Session Token Credentials
+ * @brief A structure to represent credentials used to accesss KVS.
  */
 typedef struct SignalingCredential
 {
-    const char* pAccessKeyId;
+    const char * pAccessKeyId;
     size_t accessKeyIdLength;
 
-    const char* pSecretAccessKey;
+    const char * pSecretAccessKey;
     size_t secretAccessKeyLength;
 
-    const char* pSessionToken;
+    const char * pSessionToken;
     size_t sessionTokenLength;
 
-    const char* pExpiration;
+    const char * pExpiration;
     size_t expirationLength;
-
 } SignalingCredential_t;
 
 /**

--- a/source/include/signaling_data_types.h
+++ b/source/include/signaling_data_types.h
@@ -17,6 +17,26 @@
  */
 #define SIGNALING_CHANNEL_NAME_MAX_LEN ( 256 )
 
+/**
+ * Maximum length of a Access Key.
+ */
+#define MAX_ACCESS_KEY_LEN ( 128 )
+
+/**
+ * Maximum length of a Secret Access Key.
+ */
+#define MAX_SECRET_KEY_LEN ( 128 )
+
+/**
+ * Maximum length of a Session Token.
+ */
+#define MAX_SESSION_TOKEN_LEN ( 2048 ) 
+
+/**
+ * Maximum length of a Expiration.
+ */
+#define MAX_EXPIRATION_LEN ( 128 )  
+
 /*-----------------------------------------------------------*/
 
 /**
@@ -58,6 +78,10 @@ typedef enum SignalingResult
     SIGNALING_RESULT_INVALID_ICE_SERVER_URIS_COUNT,
     SIGNALING_RESULT_INVALID_STATUS_RESPONSE,
     SIGNALING_RESULT_REGION_LENGTH_TOO_LARGE,
+    SIGNALING_RESULT_ACCESS_KEY_LENGTH_TOO_LARGE,
+    SIGNALING_RESULT_SECRET_ACCESS_KEY_LENGTH_TOO_LARGE,
+    SIGNALING_RESULT_SESSION_TOKEN_LENGTH_TOO_LARGE,
+    SIGNALING_RESULT_EXPIRATION_LENGTH_TOO_LARGE,
 } SignalingResult_t;
 
 /**
@@ -160,6 +184,27 @@ typedef struct SignalingChannelArn
     const char * pChannelArn;
     size_t channelArnLength;
 } SignalingChannelArn_t;
+
+/**
+ * @ingroup signaling_enum_types
+ * @brief Basic format of the Session Token Credentials
+ */
+typedef struct SignalingCredential
+{
+
+    const char* pAccessKeyId;
+    size_t accessKeyIdLength;
+
+    const char* pSecretAccessKey;
+    size_t secretAccessKeyLength;
+
+    const char* sessionToken;
+    size_t sessionTokenLength;
+
+    const char* expiration;
+    size_t expirationLength;
+
+} SignalingCredential_t;
 
 /**
  * @ingroup signaling_enum_types

--- a/source/signaling_api.c
+++ b/source/signaling_api.c
@@ -577,7 +577,7 @@ SignalingResult_t Signaling_ParseFetchTemporaryCredentialsResponse( const char *
             {
                 if( pair.valueLength < MAX_SESSION_TOKEN_LEN )
                 {
-                    pCredentials->sessionToken = pair.value;
+                    pCredentials->pSessionToken = pair.value;
                     pCredentials->sessionTokenLength = pair.valueLength;
                     hasSessionToken = true;
                 }
@@ -592,7 +592,7 @@ SignalingResult_t Signaling_ParseFetchTemporaryCredentialsResponse( const char *
             {
                 if( pair.valueLength < MAX_EXPIRATION_LEN )
                 {
-                    pCredentials->expiration = pair.value;
+                    pCredentials->pExpiration = pair.value;
                     pCredentials->expirationLength = pair.valueLength;
                     hasExpiration = true;
 

--- a/source/signaling_api.c
+++ b/source/signaling_api.c
@@ -434,9 +434,11 @@ SignalingResult_t Signaling_ParseDescribeSignalingChannelResponse( const char * 
 
 /*-----------------------------------------------------------*/
 
-SignalingResult_t Signaling_ConstructFetchTemporaryCredentialRequest( const char * pEndpoint, size_t endpointLength, 
-                                                                     const char * pRoleAlias, size_t roleAliasLength, 
-                                                                     SignalingRequest_t * pRequestBuffer )
+SignalingResult_t Signaling_ConstructFetchTemporaryCredentialRequest( const char * pEndpoint,
+                                                                      size_t endpointLength,
+                                                                      const char * pRoleAlias,
+                                                                      size_t roleAliasLength,
+                                                                      SignalingRequest_t * pRequestBuffer )
 {
     SignalingResult_t result = SIGNALING_RESULT_OK;
     int snprintfRetVal = 0;
@@ -474,8 +476,8 @@ SignalingResult_t Signaling_ConstructFetchTemporaryCredentialRequest( const char
 /*-----------------------------------------------------------*/
 
 SignalingResult_t Signaling_ParseFetchTemporaryCredentialsResponse( const char * pMessage,
-                                                                   size_t messageLength,
-                                                                 SignalingCredential_t *pCredentials)
+                                                                    size_t messageLength,
+                                                                    SignalingCredential_t * pCredentials )
 {
     SignalingResult_t result = SIGNALING_RESULT_OK;
     JSONStatus_t jsonResult;
@@ -490,14 +492,15 @@ SignalingResult_t Signaling_ParseFetchTemporaryCredentialsResponse( const char *
     bool hasExpiration = false;
 
     if( ( pMessage == NULL ) ||
-        ( pCredentials == NULL ))
+        ( pCredentials == NULL ) )
     {
         result = SIGNALING_RESULT_BAD_PARAM;
     }
 
     if( result == SIGNALING_RESULT_OK )
     {
-        jsonResult = JSON_Validate( pMessage, messageLength );
+        jsonResult = JSON_Validate( pMessage,
+                                    messageLength );
 
         if( jsonResult != JSONSuccess )
         {
@@ -537,7 +540,9 @@ SignalingResult_t Signaling_ParseFetchTemporaryCredentialsResponse( const char *
 
         while( jsonResult == JSONSuccess )
         {
-            if( strncmp( pair.key, "accessKeyId", pair.keyLength ) == 0 )
+            if( strncmp( pair.key,
+                         "accessKeyId",
+                         pair.keyLength ) == 0 )
             {
                 if( pair.valueLength < MAX_ACCESS_KEY_LEN )
                 {
@@ -549,9 +554,11 @@ SignalingResult_t Signaling_ParseFetchTemporaryCredentialsResponse( const char *
                 {
                     result = SIGNALING_RESULT_ACCESS_KEY_LENGTH_TOO_LARGE;
                 }
-                
+
             }
-            else if( strncmp( pair.key, "secretAccessKey", pair.keyLength ) == 0 )
+            else if( strncmp( pair.key,
+                              "secretAccessKey",
+                              pair.keyLength ) == 0 )
             {
                 if( pair.valueLength < MAX_SECRET_KEY_LEN )
                 {
@@ -564,7 +571,9 @@ SignalingResult_t Signaling_ParseFetchTemporaryCredentialsResponse( const char *
                     result = SIGNALING_RESULT_SECRET_ACCESS_KEY_LENGTH_TOO_LARGE;
                 }
             }
-            else if( strncmp( pair.key, "sessionToken", pair.keyLength ) == 0 )
+            else if( strncmp( pair.key,
+                              "sessionToken",
+                              pair.keyLength ) == 0 )
             {
                 if( pair.valueLength < MAX_SESSION_TOKEN_LEN )
                 {
@@ -577,7 +586,9 @@ SignalingResult_t Signaling_ParseFetchTemporaryCredentialsResponse( const char *
                     result = SIGNALING_RESULT_SESSION_TOKEN_LENGTH_TOO_LARGE;
                 }
             }
-            else if( strncmp( pair.key, "expiration", pair.keyLength ) == 0 )
+            else if( strncmp( pair.key,
+                              "expiration",
+                              pair.keyLength ) == 0 )
             {
                 if( pair.valueLength < MAX_EXPIRATION_LEN )
                 {
@@ -605,7 +616,8 @@ SignalingResult_t Signaling_ParseFetchTemporaryCredentialsResponse( const char *
         }
     }
 
-    if (result == SIGNALING_RESULT_OK && (!hasAccessKeyId || !hasSecretKey || !hasSessionToken || !hasExpiration)) {
+    if( ( result == SIGNALING_RESULT_OK ) && ( !hasAccessKeyId || !hasSecretKey || !hasSessionToken || !hasExpiration ) )
+    {
         result = SIGNALING_RESULT_UNEXPECTED_RESPONSE;
     }
 

--- a/source/signaling_api.c
+++ b/source/signaling_api.c
@@ -434,6 +434,171 @@ SignalingResult_t Signaling_ParseDescribeSignalingChannelResponse( const char * 
 
 /*-----------------------------------------------------------*/
 
+SignalingResult_t Signaling_ConstructSessionTokenCredentialsRequest( char * endpoint,
+                                                                     char * roleAlias,
+                                                                     SignalingRequest_t * pRequestBuffer )
+{
+    SignalingResult_t result = SIGNALING_RESULT_OK;
+    int snprintfRetVal = 0;
+
+    if( ( endpoint == NULL ) ||
+        ( roleAlias == NULL ) ||
+        ( pRequestBuffer == NULL ) ||
+        ( pRequestBuffer->pUrl == NULL ) )
+    {
+        result = SIGNALING_RESULT_BAD_PARAM;
+    }
+
+    if( result == SIGNALING_RESULT_OK )
+    {
+        snprintfRetVal = snprintf( pRequestBuffer->pUrl,
+                                   pRequestBuffer->urlLength,
+                                   "https://%s/role-aliases/%s/credentials",
+                                   endpoint,
+                                   roleAlias );
+
+        result = InterpretSnprintfReturnValue( snprintfRetVal,
+                                               pRequestBuffer->urlLength );
+
+        if( result == SIGNALING_RESULT_OK )
+        {
+            pRequestBuffer->urlLength = snprintfRetVal;
+        }
+    }
+
+    return result;
+}
+
+/*-----------------------------------------------------------*/
+
+SignalingResult_t Signaling_ParseSessionTokenCredentialsResponse( const char * pMessage,
+                                                                   size_t messageLength,
+                                                                 SignalingCredential_t *pCredentials)
+{
+    SignalingResult_t result = SIGNALING_RESULT_OK;
+    JSONStatus_t jsonResult;
+    size_t start = 0, next = 0;
+    JSONPair_t pair = { 0 };
+    const char * pCredentialsBuffer = NULL;
+    size_t credentialsBufferLength;
+    size_t credentialsStart = 0, credentialsNext = 0;
+
+    if( ( pMessage == NULL ) ||
+        ( pCredentials == NULL ))
+    {
+        result = SIGNALING_RESULT_BAD_PARAM;
+    }
+
+    if( result == SIGNALING_RESULT_OK )
+    {
+        jsonResult = JSON_Validate( pMessage, messageLength );
+
+        if( jsonResult != JSONSuccess )
+        {
+            result = SIGNALING_RESULT_INVALID_JSON;
+        }
+    }
+
+    if( result == SIGNALING_RESULT_OK )
+    {
+        memset( pCredentials, 0, sizeof( SignalingCredential_t ) );
+
+        jsonResult = JSON_Iterate( pMessage, messageLength, &( start ), &( next ), &( pair ) );
+
+        if( jsonResult == JSONSuccess )
+        {
+            if( ( pair.jsonType != JSONObject ) ||
+                ( pair.keyLength != strlen( "credentials" ) ) ||
+                ( strncmp( pair.key, "credentials", pair.keyLength ) != 0 ) )
+            {
+                result = SIGNALING_RESULT_UNEXPECTED_RESPONSE;
+            }
+            else
+            {
+                pCredentialsBuffer = pair.value;
+                credentialsBufferLength = pair.valueLength;
+            }
+        }
+        else
+        {
+            result = SIGNALING_RESULT_INVALID_JSON;
+        }
+    }
+
+    if( result == SIGNALING_RESULT_OK )
+    {
+        jsonResult = JSON_Iterate( pCredentialsBuffer, credentialsBufferLength, &( credentialsStart ), &( credentialsNext ), &( pair ) );
+
+        while( jsonResult == JSONSuccess )
+        {
+            if( strncmp( pair.key, "accessKeyId", pair.keyLength ) == 0 )
+            {
+                if( pair.valueLength < MAX_ACCESS_KEY_LEN )
+                {
+                    pCredentials->pAccessKeyId = pair.value;
+                    pCredentials->accessKeyIdLength = pair.valueLength;
+                }
+                else
+                {
+                    result = SIGNALING_RESULT_ACCESS_KEY_LENGTH_TOO_LARGE;
+                }
+                
+            }
+            else if( strncmp( pair.key, "secretAccessKey", pair.keyLength ) == 0 )
+            {
+                if( pair.valueLength < MAX_SECRET_KEY_LEN )
+                {
+                    pCredentials->pSecretAccessKey = pair.value;
+                    pCredentials->secretAccessKeyLength = pair.valueLength;
+                }
+                else
+                {
+                    result = SIGNALING_RESULT_SECRET_ACCESS_KEY_LENGTH_TOO_LARGE;
+                }
+            }
+            else if( strncmp( pair.key, "sessionToken", pair.keyLength ) == 0 )
+            {
+                if( pair.valueLength < MAX_SESSION_TOKEN_LEN )
+                {
+                    pCredentials->sessionToken = pair.value;
+                    pCredentials->sessionTokenLength = pair.valueLength;
+                }
+                else
+                {
+                    result = SIGNALING_RESULT_SESSION_TOKEN_LENGTH_TOO_LARGE;
+                }
+            }
+            else if( strncmp( pair.key, "expiration", pair.keyLength ) == 0 )
+            {
+                if( pair.valueLength < MAX_EXPIRATION_LEN )
+                {
+                    pCredentials->expiration = pair.value;
+                    pCredentials->expirationLength = pair.valueLength;
+                }
+                else
+                {
+                    result = SIGNALING_RESULT_EXPIRATION_LENGTH_TOO_LARGE;
+                }
+            }
+            else
+            {
+                /* Skip unknown attributes. */
+            }
+
+            if( result != SIGNALING_RESULT_OK )
+            {
+                break;
+            }
+
+            jsonResult = JSON_Iterate( pCredentialsBuffer, credentialsBufferLength, &( credentialsStart ), &( credentialsNext ), &( pair ) );
+        }
+    }
+
+    return result;
+}
+
+/*-----------------------------------------------------------*/
+
 SignalingResult_t Signaling_ConstructDescribeMediaStorageConfigRequest( SignalingAwsRegion_t * pAwsRegion,
                                                                         SignalingChannelArn_t * pChannelArn,
                                                                         SignalingRequest_t * pRequestBuffer )

--- a/source/signaling_api.c
+++ b/source/signaling_api.c
@@ -473,7 +473,7 @@ SignalingResult_t Signaling_ConstructFetchTemporaryCredentialRequest( const char
 
 /*-----------------------------------------------------------*/
 
-SignalingResult_t Signaling_ParseTemporaryCredentialsResponse( const char * pMessage,
+SignalingResult_t Signaling_ParseFetchTemporaryCredentialsResponse( const char * pMessage,
                                                                    size_t messageLength,
                                                                  SignalingCredential_t *pCredentials)
 {

--- a/test/unit-test/signaling_api/signaling_api_utest.c
+++ b/test/unit-test/signaling_api/signaling_api_utest.c
@@ -666,40 +666,42 @@ void test_signaling_ParseDescribeSignalingChannelResponse( void )
 /**
  * @brief Validate Signaling Construct Session Token Credentials Request fail functionality for Bad Parameters.
  */
-void test_signaling_ConstructSessionTokenCredentialsRequest_BadParams( void )
+void test_signaling_ConstructFetchTemporaryCredentialRequest_BadParams( void )
 {
-    char * pEndpoint = "abcdef.credentials.iot.us-west-2.amazonaws.com";
-    char * pRoleAlias = "TestRoleAlias";
+    const char * pEndpoint = "abcdef.credentials.iot.us-west-2.amazonaws.com";
+    size_t endpointLength = strlen( pEndpoint );
+    const char * pRoleAlias = "TestRoleAlias";
+    size_t roleAliasLength = strlen( pRoleAlias );
     SignalingRequest_t requestBuffer = { 0 };
     SignalingResult_t result;
 
 
-    result = Signaling_ConstructSessionTokenCredentialsRequest( NULL,
-                                                                ( pRoleAlias ),
+    result = Signaling_ConstructFetchTemporaryCredentialRequest( NULL, endpointLength,
+                                                                ( pRoleAlias ), roleAliasLength,
                                                                 &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
 
-    result = Signaling_ConstructSessionTokenCredentialsRequest( ( pEndpoint ),
-                                                                NULL,
+    result = Signaling_ConstructFetchTemporaryCredentialRequest( ( pEndpoint ), endpointLength,
+                                                                NULL,  roleAliasLength,
                                                                 &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
 
-    result = Signaling_ConstructSessionTokenCredentialsRequest( ( pEndpoint ),
-                                                                ( pRoleAlias ),
+    result = Signaling_ConstructFetchTemporaryCredentialRequest( ( pEndpoint ), endpointLength,
+                                                                ( pRoleAlias ), roleAliasLength,
                                                                 NULL );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     requestBuffer.pUrl = NULL;
-    result = Signaling_ConstructSessionTokenCredentialsRequest( ( pEndpoint ),
-                                                                ( pRoleAlias ),
+    result = Signaling_ConstructFetchTemporaryCredentialRequest( ( pEndpoint ), endpointLength,
+                                                                ( pRoleAlias ), roleAliasLength,
                                                                 &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
@@ -712,10 +714,12 @@ void test_signaling_ConstructSessionTokenCredentialsRequest_BadParams( void )
 /**
  * @brief Validate Signaling Construct Describe Media Storage Config Request functionality.
  */
-void test_signaling_ConstructSessionTokenCredentialsRequest_UrlOutOfMemory( void )
+void test_signaling_ConstructFetchTemporaryCredentialRequest_UrlOutOfMemory( void )
 {
-    char * pEndpoint = "abcdef.credentials.iot.us-west-2.amazonaws.com";
-    char * pRoleAlias = "TestRoleAlias";
+    const char * pEndpoint = "abcdef.credentials.iot.us-west-2.amazonaws.com";
+    size_t endpointLength = strlen( pEndpoint );
+    const char * pRoleAlias = "TestRoleAlias";
+    size_t roleAliasLength = strlen( pRoleAlias );
     SignalingRequest_t requestBuffer = { 0 };
     SignalingResult_t result;
     char urlBuffer[ 50 ];/* The url buffer is too small to fit the complete URL. */
@@ -723,8 +727,8 @@ void test_signaling_ConstructSessionTokenCredentialsRequest_UrlOutOfMemory( void
     requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
 
-    result = Signaling_ConstructSessionTokenCredentialsRequest( ( pEndpoint ),
-                                                                ( pRoleAlias ),
+    result = Signaling_ConstructFetchTemporaryCredentialRequest( ( pEndpoint ), endpointLength,
+                                                                ( pRoleAlias ), roleAliasLength,
                                                                 &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
@@ -736,10 +740,12 @@ void test_signaling_ConstructSessionTokenCredentialsRequest_UrlOutOfMemory( void
 /**
  * @brief Validate Signaling Construct Session Token Credentials Request functionality.
  */
-void test_signaling_ConstructSessionTokenCredentialsRequest( void )
+void test_signaling_ConstructFetchTemporaryCredentialRequest( void )
 {
-    char * pEndpoint = "abcdef.credentials.iot.us-west-2.amazonaws.com";
-    char * pRoleAlias = "TestRoleAlias";
+    const char * pEndpoint = "abcdef.credentials.iot.us-west-2.amazonaws.com";
+    size_t endpointLength = strlen( pEndpoint );
+    const char * pRoleAlias = "TestRoleAlias";
+    size_t roleAliasLength = strlen( pRoleAlias );
     SignalingRequest_t requestBuffer = { 0 };
     SignalingResult_t result;
     char urlBuffer[ 200 ];
@@ -748,8 +754,8 @@ void test_signaling_ConstructSessionTokenCredentialsRequest( void )
     requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
 
-    result = Signaling_ConstructSessionTokenCredentialsRequest( ( pEndpoint ),
-                                                                ( pRoleAlias ),
+    result = Signaling_ConstructFetchTemporaryCredentialRequest( ( pEndpoint ), endpointLength,
+                                                                ( pRoleAlias ), roleAliasLength,
                                                                 &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
@@ -766,21 +772,21 @@ void test_signaling_ConstructSessionTokenCredentialsRequest( void )
 /**
  * @brief Validate Signaling Parse Session Token Credentials fail functionality for Bad Parameters.
  */
-void test_signaling_ParseSessionTokenCredentialsResponse_BadParams( void )
+void test_signaling_ParseTemporaryCredentialsResponse_BadParams( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
     const char * pMessage = "Valid-Message";
     size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseSessionTokenCredentialsResponse( NULL,
+    result = Signaling_ParseTemporaryCredentialsResponse( NULL,
                                                              messageLength,
                                                              &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    result = Signaling_ParseSessionTokenCredentialsResponse( pMessage,
+    result = Signaling_ParseTemporaryCredentialsResponse( pMessage,
                                                              messageLength,
                                                              NULL );
 
@@ -793,14 +799,14 @@ void test_signaling_ParseSessionTokenCredentialsResponse_BadParams( void )
 /**
  * @brief Validate Signaling Parse Session Token Credentials functionality.
  */
-void test_signaling_ParseSessionTokenCredentialsResponse_InvalidJson( void )
+void test_signaling_ParseTemporaryCredentialsResponse_InvalidJson( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
     const char * pMessage = "{\"credentials\": {";  /* Missing closing brace. */
     size_t messageLength = sizeof( pMessage );
 
-    result = Signaling_ParseSessionTokenCredentialsResponse( pMessage,
+    result = Signaling_ParseTemporaryCredentialsResponse( pMessage,
                                                              messageLength,
                                                              &( credentials ) );
 
@@ -812,7 +818,7 @@ void test_signaling_ParseSessionTokenCredentialsResponse_InvalidJson( void )
     const char * pMessage2 = "{}"; /* Empty JSON. */
     size_t messageLength2 = strlen( pMessage2 );
 
-    result = Signaling_ParseSessionTokenCredentialsResponse( pMessage2,
+    result = Signaling_ParseTemporaryCredentialsResponse( pMessage2,
                                                              messageLength2,
                                                              &( credentials ) );
 
@@ -825,7 +831,7 @@ void test_signaling_ParseSessionTokenCredentialsResponse_InvalidJson( void )
 /**
  * @brief Validate Signaling Parse Describe Response functionality for Unexpected Response.
  */
-void test_signaling_ParseSessionTokenCredentialsResponse_UnexpectedResponse( void )
+void test_signaling_ParseTemporaryCredentialsResponse_UnexpectedResponse( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
@@ -840,7 +846,7 @@ void test_signaling_ParseSessionTokenCredentialsResponse_UnexpectedResponse( voi
     "}";
     size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseSessionTokenCredentialsResponse( pMessage,
+    result = Signaling_ParseTemporaryCredentialsResponse( pMessage,
                                                              messageLength,
                                                              &( credentials ) );
 
@@ -858,7 +864,7 @@ void test_signaling_ParseSessionTokenCredentialsResponse_UnexpectedResponse( voi
     "}";
     size_t messageLength2 = strlen( pMessage2 );
 
-    result = Signaling_ParseSessionTokenCredentialsResponse( pMessage2,
+    result = Signaling_ParseTemporaryCredentialsResponse( pMessage2,
                                                              messageLength2,
                                                              &( credentials ) );
 
@@ -873,7 +879,7 @@ void test_signaling_ParseSessionTokenCredentialsResponse_UnexpectedResponse( voi
     "}";
     size_t messageLength3 = strlen( pMessage3 );
 
-    result = Signaling_ParseSessionTokenCredentialsResponse( pMessage3,
+    result = Signaling_ParseTemporaryCredentialsResponse( pMessage3,
                                                              messageLength3,
                                                              &( credentials ) );
 
@@ -886,7 +892,7 @@ void test_signaling_ParseSessionTokenCredentialsResponse_UnexpectedResponse( voi
 /**
  * @brief Validate Signaling Parse Session Token Response functionality for too long Access Key.
  */
-void test_signaling_ParseSessionTokenCredentialsResponse_AccessKeyTooLong( void )
+void test_signaling_ParseTemporaryCredentialsResponse_AccessKeyTooLong( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
@@ -909,7 +915,7 @@ void test_signaling_ParseSessionTokenCredentialsResponse_AccessKeyTooLong( void 
                longAccessKey );
     size_t messageLength = strlen( message );
 
-    result = Signaling_ParseSessionTokenCredentialsResponse( &( message[ 0 ] ),
+    result = Signaling_ParseTemporaryCredentialsResponse( &( message[ 0 ] ),
                                                              messageLength,
                                                              &( credentials ) );
 
@@ -922,7 +928,7 @@ void test_signaling_ParseSessionTokenCredentialsResponse_AccessKeyTooLong( void 
 /**
  * @brief Validate Signaling Parse Session Token Response functionality for too long Secret Access Key.
  */
-void test_signaling_ParseSessionTokenCredentialsResponse_SecretAccessKeyTooLong( void )
+void test_signaling_ParseTemporaryCredentialsResponse_SecretAccessKeyTooLong( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
@@ -946,7 +952,7 @@ void test_signaling_ParseSessionTokenCredentialsResponse_SecretAccessKeyTooLong(
                longSecretAccessKey );
     size_t messageLength = strlen( message );
 
-    result = Signaling_ParseSessionTokenCredentialsResponse( &( message[ 0 ] ),
+    result = Signaling_ParseTemporaryCredentialsResponse( &( message[ 0 ] ),
                                                              messageLength,
                                                              &( credentials ) );
 
@@ -959,7 +965,7 @@ void test_signaling_ParseSessionTokenCredentialsResponse_SecretAccessKeyTooLong(
 /**
  * @brief Validate Signaling Parse Session Token Response functionality for too long Session Token.
  */
-void test_signaling_ParseSessionTokenCredentialsResponse_SessionTokenTooLong( void )
+void test_signaling_ParseTemporaryCredentialsResponse_SessionTokenTooLong( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
@@ -984,7 +990,7 @@ void test_signaling_ParseSessionTokenCredentialsResponse_SessionTokenTooLong( vo
                longSessionToken );
     size_t messageLength = strlen( message );
 
-    result = Signaling_ParseSessionTokenCredentialsResponse( &( message[ 0 ] ),
+    result = Signaling_ParseTemporaryCredentialsResponse( &( message[ 0 ] ),
                                                              messageLength,
                                                              &( credentials ) );
 
@@ -997,7 +1003,7 @@ void test_signaling_ParseSessionTokenCredentialsResponse_SessionTokenTooLong( vo
 /**
  * @brief Validate Signaling Parse Session Token Response functionality for too long Expiration.
  */
-void test_signaling_ParseSessionTokenCredentialsResponse_ExpirationTooLong( void )
+void test_signaling_ParseTemporaryCredentialsResponse_ExpirationTooLong( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
@@ -1023,7 +1029,7 @@ void test_signaling_ParseSessionTokenCredentialsResponse_ExpirationTooLong( void
                longExpiration );
     size_t messageLength = strlen( message );
 
-    result = Signaling_ParseSessionTokenCredentialsResponse( &( message[ 0 ] ),
+    result = Signaling_ParseTemporaryCredentialsResponse( &( message[ 0 ] ),
                                                              messageLength,
                                                              &( credentials ) );
 
@@ -1034,9 +1040,121 @@ void test_signaling_ParseSessionTokenCredentialsResponse_ExpirationTooLong( void
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate Signaling Parse Describe Response functionality.
+ * @brief Validate Signaling Parse Temporary Credential Response functionality.
  */
-void test_signaling_ParseSessionTokenCredentialsResponse( void )
+void test_signaling_ParseTemporaryCredentialsResponse_NoAccessKey( void )
+{
+    SignalingCredential_t credentials;
+    SignalingResult_t result;
+    const char * pMessage =
+    "{"
+        "\"credentials\":"
+        "{"                                                     /* No Access Key */
+            "\"secretAccessKey\": \"test-e/I5Zjd72kMzF/Ys20Le9wyxH3\","
+            "\"sessionToken\": \"IQoJb3JpZ2luX3TT5KsgDCNv//////////wEQABoM4L2LJKaRl/zI1I+48vpNn40TZ5wXfyWtqmqLWVNYHbxLdCOelXF9OnyCzvG6X5CPLQsgU/wT3QQ=\","
+            "\"expiration\": \"2024-12-23T18:26:52Z\","
+            "\"Unknown\": \"200\"" /* Unknown Tag --> Will be skipped. */
+        "}"
+    "}";
+    size_t messageLength = strlen( pMessage );
+    result = Signaling_ParseTemporaryCredentialsResponse( pMessage,
+                                                             messageLength,
+                                                             &( credentials ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Temporary Credential Response functionality.
+ */
+void test_signaling_ParseTemporaryCredentialsResponse_NoSecretAccessKey( void )
+{
+    SignalingCredential_t credentials;
+    SignalingResult_t result;
+    const char * pMessage =
+    "{"
+        "\"credentials\":"
+        "{"                                                     /* No SecretAccess Key */
+            "\"accessKeyId\": \"ASIASWNFWKDLG25\","
+            "\"sessionToken\": \"IQoJb3JpZ2luX3TT5KsgDCNv//////////wEQABoM4L2LJKaRl/zI1I+48vpNn40TZ5wXfyWtqmqLWVNYHbxLdCOelXF9OnyCzvG6X5CPLQsgU/wT3QQ=\","
+            "\"expiration\": \"2024-12-23T18:26:52Z\","
+            "\"Unknown\": \"200\"" /* Unknown Tag --> Will be skipped. */
+        "}"
+    "}";
+    size_t messageLength = strlen( pMessage );
+    result = Signaling_ParseTemporaryCredentialsResponse( pMessage,
+                                                             messageLength,
+                                                             &( credentials ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Temporary Credential Response functionality.
+ */
+void test_signaling_ParseTemporaryCredentialsResponse_NoSessionToken( void )
+{
+    SignalingCredential_t credentials;
+    SignalingResult_t result;
+    const char * pMessage =
+    "{"
+        "\"credentials\":"
+        "{"                                                     /* No Session Token  */
+            "\"accessKeyId\": \"ASIASWNFWKDLG25\","
+            "\"secretAccessKey\": \"test-e/I5Zjd72kMzF/Ys20Le9wyxH3\","
+            "\"expiration\": \"2024-12-23T18:26:52Z\","
+            "\"Unknown\": \"200\"" /* Unknown Tag --> Will be skipped. */
+        "}"
+    "}";
+    size_t messageLength = strlen( pMessage );
+    result = Signaling_ParseTemporaryCredentialsResponse( pMessage,
+                                                             messageLength,
+                                                             &( credentials ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Temporary Credential Response functionality.
+ */
+void test_signaling_ParseTemporaryCredentialsResponse_NoExpiration( void )
+{
+    SignalingCredential_t credentials;
+    SignalingResult_t result;
+    const char * pMessage =
+    "{"
+        "\"credentials\":"
+        "{"                                                     /* No Expiration  */
+            "\"accessKeyId\": \"ASIASWNFWKDLG25\","
+            "\"secretAccessKey\": \"test-e/I5Zjd72kMzF/Ys20Le9wyxH3\","
+            "\"sessionToken\": \"IQoJb3JpZ2luX3TT5KsgDCNv//////////wEQABoM4L2LJKaRl/zI1I+48vpNn40TZ5wXfyWtqmqLWVNYHbxLdCOelXF9OnyCzvG6X5CPLQsgU/wT3QQ=\","
+            "\"Unknown\": \"200\"" /* Unknown Tag --> Will be skipped. */
+        "}"
+    "}";
+    size_t messageLength = strlen( pMessage );
+    result = Signaling_ParseTemporaryCredentialsResponse( pMessage,
+                                                             messageLength,
+                                                             &( credentials ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
+                       result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Parse Temporary Credential Response functionality.
+ */
+void test_signaling_ParseTemporaryCredentialsResponse( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
@@ -1057,7 +1175,7 @@ void test_signaling_ParseSessionTokenCredentialsResponse( void )
     const char * pExpectedSessionToken = "IQoJb3JpZ2luX3TT5KsgDCNv//////////wEQABoM4L2LJKaRl/zI1I+48vpNn40TZ5wXfyWtqmqLWVNYHbxLdCOelXF9OnyCzvG6X5CPLQsgU/wT3QQ=";
     const char * pExpectedExpiration = "2024-12-23T18:26:52Z";
 
-    result = Signaling_ParseSessionTokenCredentialsResponse( pMessage,
+    result = Signaling_ParseTemporaryCredentialsResponse( pMessage,
                                                              messageLength,
                                                              &( credentials ) );
 

--- a/test/unit-test/signaling_api/signaling_api_utest.c
+++ b/test/unit-test/signaling_api/signaling_api_utest.c
@@ -664,9 +664,9 @@ void test_signaling_ParseDescribeSignalingChannelResponse( void )
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate Signaling Construct Session Token Credentials Request fail functionality for Bad Parameters.
+ * @brief Validate Signaling Construct Fetch Temporary Credentials Request fail functionality for Bad Parameters.
  */
-void test_signaling_ConstructFetchTemporaryCredentialRequest_BadParams( void )
+void test_signaling_ConstructFetchTempCredsRequestForAwsIot_BadParams( void )
 {
     const char * pEndpoint = "abcdef.credentials.iot.us-west-2.amazonaws.com";
     size_t endpointLength = strlen( pEndpoint );
@@ -675,54 +675,51 @@ void test_signaling_ConstructFetchTemporaryCredentialRequest_BadParams( void )
     SignalingRequest_t requestBuffer = { 0 };
     SignalingResult_t result;
 
-
-    result = Signaling_ConstructFetchTemporaryCredentialRequest( NULL,
-                                                                 endpointLength,
-                                                                 ( pRoleAlias ),
-                                                                 roleAliasLength,
-                                                                 &( requestBuffer ) );
-
-    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
-                       result );
-
-
-    result = Signaling_ConstructFetchTemporaryCredentialRequest( ( pEndpoint ),
-                                                                 endpointLength,
-                                                                 NULL,
-                                                                 roleAliasLength,
-                                                                 &( requestBuffer ) );
+    result = Signaling_ConstructFetchTempCredsRequestForAwsIot( NULL,
+                                                                endpointLength,
+                                                                pRoleAlias,
+                                                                roleAliasLength,
+                                                                &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
+    result = Signaling_ConstructFetchTempCredsRequestForAwsIot( pEndpoint,
+                                                                endpointLength,
+                                                                NULL,
+                                                                roleAliasLength,
+                                                                &( requestBuffer ) );
 
-    result = Signaling_ConstructFetchTemporaryCredentialRequest( ( pEndpoint ),
-                                                                 endpointLength,
-                                                                 ( pRoleAlias ),
-                                                                 roleAliasLength,
-                                                                 NULL );
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
+                       result );
+
+    result = Signaling_ConstructFetchTempCredsRequestForAwsIot( pEndpoint,
+                                                                endpointLength,
+                                                                pRoleAlias,
+                                                                roleAliasLength,
+                                                                NULL );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     requestBuffer.pUrl = NULL;
-    result = Signaling_ConstructFetchTemporaryCredentialRequest( ( pEndpoint ),
-                                                                 endpointLength,
-                                                                 ( pRoleAlias ),
-                                                                 roleAliasLength,
-                                                                 &( requestBuffer ) );
+
+    result = Signaling_ConstructFetchTempCredsRequestForAwsIot( pEndpoint,
+                                                                endpointLength,
+                                                                pRoleAlias,
+                                                                roleAliasLength,
+                                                                &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
-
 }
 
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate Signaling Construct Describe Media Storage Config Request functionality.
+ * @brief Validate Signaling Construct Fetch Temporary Credentials Request functionality.
  */
-void test_signaling_ConstructFetchTemporaryCredentialRequest_UrlOutOfMemory( void )
+void test_signaling_ConstructFetchTempCredsRequestForAwsIot_UrlOutOfMemory( void )
 {
     const char * pEndpoint = "abcdef.credentials.iot.us-west-2.amazonaws.com";
     size_t endpointLength = strlen( pEndpoint );
@@ -735,11 +732,11 @@ void test_signaling_ConstructFetchTemporaryCredentialRequest_UrlOutOfMemory( voi
     requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
 
-    result = Signaling_ConstructFetchTemporaryCredentialRequest( ( pEndpoint ),
-                                                                 endpointLength,
-                                                                 ( pRoleAlias ),
-                                                                 roleAliasLength,
-                                                                 &( requestBuffer ) );
+    result = Signaling_ConstructFetchTempCredsRequestForAwsIot( pEndpoint,
+                                                                endpointLength,
+                                                                pRoleAlias,
+                                                                roleAliasLength,
+                                                                &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
                        result );
@@ -748,9 +745,9 @@ void test_signaling_ConstructFetchTemporaryCredentialRequest_UrlOutOfMemory( voi
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate Signaling Construct Session Token Credentials Request functionality.
+ * @brief Validate Signaling Construct Fetch Temporary Credentials Request functionality.
  */
-void test_signaling_ConstructFetchTemporaryCredentialRequest( void )
+void test_signaling_ConstructFetchTempCredsRequestForAwsIot( void )
 {
     const char * pEndpoint = "abcdef.credentials.iot.us-west-2.amazonaws.com";
     size_t endpointLength = strlen( pEndpoint );
@@ -764,11 +761,11 @@ void test_signaling_ConstructFetchTemporaryCredentialRequest( void )
     requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
 
-    result = Signaling_ConstructFetchTemporaryCredentialRequest( ( pEndpoint ),
-                                                                 endpointLength,
-                                                                 ( pRoleAlias ),
-                                                                 roleAliasLength,
-                                                                 &( requestBuffer ) );
+    result = Signaling_ConstructFetchTempCredsRequestForAwsIot( pEndpoint,
+                                                                endpointLength,
+                                                                pRoleAlias,
+                                                                roleAliasLength,
+                                                                &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
@@ -782,25 +779,25 @@ void test_signaling_ConstructFetchTemporaryCredentialRequest( void )
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate Signaling Parse Session Token Credentials fail functionality for Bad Parameters.
+ * @brief Validate Signaling Parse Temporary Credentials fail functionality for Bad Parameters.
  */
-void test_signaling_ParseFetchTemporaryCredentialsResponse_BadParams( void )
+void test_signaling_ParseFetchTempCredsResponseFromAwsIot_BadParams( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
     const char * pMessage = "Valid-Message";
     size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseFetchTemporaryCredentialsResponse( NULL,
-                                                               messageLength,
-                                                               &( credentials ) );
+    result = Signaling_ParseFetchTempCredsResponseFromAwsIot( NULL,
+                                                              messageLength,
+                                                              &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage,
-                                                               messageLength,
-                                                               NULL );
+    result = Signaling_ParseFetchTempCredsResponseFromAwsIot( pMessage,
+                                                              messageLength,
+                                                              NULL );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -809,30 +806,28 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_BadParams( void )
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate Signaling Parse Session Token Credentials functionality.
+ * @brief Validate Signaling ParseTemporary Credentials functionality.
  */
-void test_signaling_ParseFetchTemporaryCredentialsResponse_InvalidJson( void )
+void test_signaling_ParseFetchTempCredsResponseFromAwsIot_InvalidJson( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
-    const char * pMessage = "{\"credentials\": {";  /* Missing closing brace. */
+    const char * pMessage = "{\"credentials\": {"; /* Missing closing brace. */
     size_t messageLength = sizeof( pMessage );
 
-    result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage,
-                                                               messageLength,
-                                                               &( credentials ) );
+    result = Signaling_ParseFetchTempCredsResponseFromAwsIot( pMessage,
+                                                              messageLength,
+                                                              &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
                        result );
-
-    /* <--------------------------------------------------------------------> */
 
     const char * pMessage2 = "{}"; /* Empty JSON. */
     size_t messageLength2 = strlen( pMessage2 );
 
-    result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage2,
-                                                               messageLength2,
-                                                               &( credentials ) );
+    result = Signaling_ParseFetchTempCredsResponseFromAwsIot( pMessage2,
+                                                              messageLength2,
+                                                              &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
                        result );
@@ -841,9 +836,9 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_InvalidJson( void )
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate Signaling Parse Describe Response functionality for Unexpected Response.
+ * @brief Validate Signaling Parse Temporary Credentials functionality for Unexpected Response.
  */
-void test_signaling_ParseFetchTemporaryCredentialsResponse_UnexpectedResponse( void )
+void test_signaling_ParseFetchTempCredsResponseFromAwsIot_UnexpectedResponse( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
@@ -858,14 +853,12 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_UnexpectedResponse( v
     "}";
     size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage,
-                                                               messageLength,
-                                                               &( credentials ) );
+    result = Signaling_ParseFetchTempCredsResponseFromAwsIot( pMessage,
+                                                              messageLength,
+                                                              &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
-
-    /* <--------------------------------------------------------------------> */
 
     const char * pMessage2 =
     "{"
@@ -876,14 +869,12 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_UnexpectedResponse( v
     "}";
     size_t messageLength2 = strlen( pMessage2 );
 
-    result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage2,
-                                                               messageLength2,
-                                                               &( credentials ) );
+    result = Signaling_ParseFetchTempCredsResponseFromAwsIot( pMessage2,
+                                                              messageLength2,
+                                                              &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
-
-    /* <--------------------------------------------------------------------> */
 
     const char * pMessage3 =
     "{"
@@ -891,9 +882,9 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_UnexpectedResponse( v
     "}";
     size_t messageLength3 = strlen( pMessage3 );
 
-    result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage3,
-                                                               messageLength3,
-                                                               &( credentials ) );
+    result = Signaling_ParseFetchTempCredsResponseFromAwsIot( pMessage3,
+                                                              messageLength3,
+                                                              &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
@@ -902,13 +893,13 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_UnexpectedResponse( v
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate Signaling Parse Session Token Response functionality for too long Access Key.
+ * @brief Validate Signaling Parse Temporary Credentials functionality for too long Access Key.
  */
-void test_signaling_ParseFetchTemporaryCredentialsResponse_AccessKeyTooLong( void )
+void test_signaling_ParseFetchTempCredsResponseFromAwsIot_AccessKeyTooLong( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
-    char longAccessKey[ MAX_ACCESS_KEY_LEN + 10 ];
+    char longAccessKey[ ACCESS_KEY_MAX_LEN + 10 ];
     char message[ 1000 ];
 
     memset( &( longAccessKey[ 0 ] ),
@@ -927,9 +918,9 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_AccessKeyTooLong( voi
                longAccessKey );
     size_t messageLength = strlen( message );
 
-    result = Signaling_ParseFetchTemporaryCredentialsResponse( &( message[ 0 ] ),
-                                                               messageLength,
-                                                               &( credentials ) );
+    result = Signaling_ParseFetchTempCredsResponseFromAwsIot( &( message[ 0 ] ),
+                                                              messageLength,
+                                                              &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_ACCESS_KEY_LENGTH_TOO_LARGE,
                        result );
@@ -938,13 +929,13 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_AccessKeyTooLong( voi
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate Signaling Parse Session Token Response functionality for too long Secret Access Key.
+ * @brief Validate Signaling Parse Temporary Credentials functionality for too long Secret Access Key.
  */
-void test_signaling_ParseFetchTemporaryCredentialsResponse_SecretAccessKeyTooLong( void )
+void test_signaling_ParseFetchTempCredsResponseFromAwsIot_SecretAccessKeyTooLong( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
-    char longSecretAccessKey[ MAX_SECRET_KEY_LEN + 10 ];
+    char longSecretAccessKey[ SECRET_ACCESS_KEY_MAX_LEN + 10 ];
     char message[ 1000 ];
 
     memset( &( longSecretAccessKey[ 0 ] ),
@@ -964,9 +955,9 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_SecretAccessKeyTooLon
                longSecretAccessKey );
     size_t messageLength = strlen( message );
 
-    result = Signaling_ParseFetchTemporaryCredentialsResponse( &( message[ 0 ] ),
-                                                               messageLength,
-                                                               &( credentials ) );
+    result = Signaling_ParseFetchTempCredsResponseFromAwsIot( &( message[ 0 ] ),
+                                                              messageLength,
+                                                              &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_SECRET_ACCESS_KEY_LENGTH_TOO_LARGE,
                        result );
@@ -975,13 +966,13 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_SecretAccessKeyTooLon
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate Signaling Parse Session Token Response functionality for too long Session Token.
+ * @brief Validate Signaling Parse Temporary Credentials functionality for too long Session Token.
  */
-void test_signaling_ParseFetchTemporaryCredentialsResponse_SessionTokenTooLong( void )
+void test_signaling_ParseFetchTempCredsResponseFromAwsIot_SessionTokenTooLong( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
-    char longSessionToken[ MAX_SESSION_TOKEN_LEN + 10 ];
+    char longSessionToken[ SESSION_TOKEN_MAX_LEN + 10 ];
     char message[ 3000 ];
 
     memset( &( longSessionToken[ 0 ] ),
@@ -1002,9 +993,9 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_SessionTokenTooLong( 
                longSessionToken );
     size_t messageLength = strlen( message );
 
-    result = Signaling_ParseFetchTemporaryCredentialsResponse( &( message[ 0 ] ),
-                                                               messageLength,
-                                                               &( credentials ) );
+    result = Signaling_ParseFetchTempCredsResponseFromAwsIot( &( message[ 0 ] ),
+                                                              messageLength,
+                                                              &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_SESSION_TOKEN_LENGTH_TOO_LARGE,
                        result );
@@ -1013,13 +1004,13 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_SessionTokenTooLong( 
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate Signaling Parse Session Token Response functionality for too long Expiration.
+ * @brief Validate Signaling Parse Temporary Credentials functionality for too long Expiration.
  */
-void test_signaling_ParseFetchTemporaryCredentialsResponse_ExpirationTooLong( void )
+void test_signaling_ParseFetchTempCredsResponseFromAwsIot_ExpirationTooLong( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
-    char longExpiration[ MAX_EXPIRATION_LEN + 10 ];
+    char longExpiration[ EXPIRATION_MAX_LEN + 10 ];
     char message[ 1000 ];
 
     memset( &( longExpiration[ 0 ] ),
@@ -1041,9 +1032,9 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_ExpirationTooLong( vo
                longExpiration );
     size_t messageLength = strlen( message );
 
-    result = Signaling_ParseFetchTemporaryCredentialsResponse( &( message[ 0 ] ),
-                                                               messageLength,
-                                                               &( credentials ) );
+    result = Signaling_ParseFetchTempCredsResponseFromAwsIot( &( message[ 0 ] ),
+                                                              messageLength,
+                                                              &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_EXPIRATION_LENGTH_TOO_LARGE,
                        result );
@@ -1052,16 +1043,16 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_ExpirationTooLong( vo
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate Signaling Parse Temporary Credential Response functionality.
+ * @brief Validate Signaling Parse Temporary Credentials Response functionality.
  */
-void test_signaling_ParseFetchTemporaryCredentialsResponse_NoAccessKey( void )
+void test_signaling_ParseFetchTempCredsResponseFromAwsIot_NoAccessKey( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
     const char * pMessage =
     "{"
         "\"credentials\":"
-        "{"                                                     /* No Access Key */
+        "{" /* No Access Key. */
             "\"secretAccessKey\": \"test-e/I5Zjd72kMzF/Ys20Le9wyxH3\","
             "\"sessionToken\": \"IQoJb3JpZ2luX3TT5KsgDCNv//////////wEQABoM4L2LJKaRl/zI1I+48vpNn40TZ5wXfyWtqmqLWVNYHbxLdCOelXF9OnyCzvG6X5CPLQsgU/wT3QQ=\","
             "\"expiration\": \"2024-12-23T18:26:52Z\","
@@ -1069,9 +1060,10 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_NoAccessKey( void )
         "}"
     "}";
     size_t messageLength = strlen( pMessage );
-    result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage,
-                                                               messageLength,
-                                                               &( credentials ) );
+
+    result = Signaling_ParseFetchTempCredsResponseFromAwsIot( pMessage,
+                                                              messageLength,
+                                                              &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
@@ -1080,16 +1072,16 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_NoAccessKey( void )
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate Signaling Parse Temporary Credential Response functionality.
+ * @brief Validate Signaling Parse Temporary Credentials Response functionality.
  */
-void test_signaling_ParseFetchTemporaryCredentialsResponse_NoSecretAccessKey( void )
+void test_signaling_ParseFetchTempCredsResponseFromAwsIot_NoSecretAccessKey( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
     const char * pMessage =
     "{"
         "\"credentials\":"
-        "{"                                                     /* No SecretAccess Key */
+        "{" /* No Secret Access Key. */
             "\"accessKeyId\": \"ASIASWNFWKDLG25\","
             "\"sessionToken\": \"IQoJb3JpZ2luX3TT5KsgDCNv//////////wEQABoM4L2LJKaRl/zI1I+48vpNn40TZ5wXfyWtqmqLWVNYHbxLdCOelXF9OnyCzvG6X5CPLQsgU/wT3QQ=\","
             "\"expiration\": \"2024-12-23T18:26:52Z\","
@@ -1097,9 +1089,10 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_NoSecretAccessKey( vo
         "}"
     "}";
     size_t messageLength = strlen( pMessage );
-    result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage,
-                                                               messageLength,
-                                                               &( credentials ) );
+
+    result = Signaling_ParseFetchTempCredsResponseFromAwsIot( pMessage,
+                                                              messageLength,
+                                                              &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
@@ -1108,16 +1101,16 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_NoSecretAccessKey( vo
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate Signaling Parse Temporary Credential Response functionality.
+ * @brief Validate Signaling Parse Temporary Credentials Response functionality.
  */
-void test_signaling_ParseFetchTemporaryCredentialsResponse_NoSessionToken( void )
+void test_signaling_ParseFetchTempCredsResponseFromAwsIot_NoSessionToken( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
     const char * pMessage =
     "{"
         "\"credentials\":"
-        "{"                                                     /* No Session Token  */
+        "{" /* No Session Token. */
             "\"accessKeyId\": \"ASIASWNFWKDLG25\","
             "\"secretAccessKey\": \"test-e/I5Zjd72kMzF/Ys20Le9wyxH3\","
             "\"expiration\": \"2024-12-23T18:26:52Z\","
@@ -1125,9 +1118,10 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_NoSessionToken( void 
         "}"
     "}";
     size_t messageLength = strlen( pMessage );
-    result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage,
-                                                               messageLength,
-                                                               &( credentials ) );
+
+    result = Signaling_ParseFetchTempCredsResponseFromAwsIot( pMessage,
+                                                              messageLength,
+                                                              &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
@@ -1136,16 +1130,16 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_NoSessionToken( void 
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate Signaling Parse Temporary Credential Response functionality.
+ * @brief Validate Signaling Parse Temporary Credentials Response functionality.
  */
-void test_signaling_ParseFetchTemporaryCredentialsResponse_NoExpiration( void )
+void test_signaling_ParseFetchTempCredsResponseFromAwsIot_NoExpiration( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
     const char * pMessage =
     "{"
         "\"credentials\":"
-        "{"                                                     /* No Expiration  */
+        "{" /* No Expiration. */
             "\"accessKeyId\": \"ASIASWNFWKDLG25\","
             "\"secretAccessKey\": \"test-e/I5Zjd72kMzF/Ys20Le9wyxH3\","
             "\"sessionToken\": \"IQoJb3JpZ2luX3TT5KsgDCNv//////////wEQABoM4L2LJKaRl/zI1I+48vpNn40TZ5wXfyWtqmqLWVNYHbxLdCOelXF9OnyCzvG6X5CPLQsgU/wT3QQ=\","
@@ -1153,9 +1147,10 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_NoExpiration( void )
         "}"
     "}";
     size_t messageLength = strlen( pMessage );
-    result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage,
-                                                               messageLength,
-                                                               &( credentials ) );
+
+    result = Signaling_ParseFetchTempCredsResponseFromAwsIot( pMessage,
+                                                              messageLength,
+                                                              &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
@@ -1164,9 +1159,9 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_NoExpiration( void )
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Validate Signaling Parse Temporary Credential Response functionality.
+ * @brief Validate Signaling Parse Temporary Credentials Response functionality.
  */
-void test_signaling_ParseFetchTemporaryCredentialsResponse( void )
+void test_signaling_ParseFetchTempCredsResponseFromAwsIot( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
@@ -1187,9 +1182,9 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse( void )
     const char * pExpectedSessionToken = "IQoJb3JpZ2luX3TT5KsgDCNv//////////wEQABoM4L2LJKaRl/zI1I+48vpNn40TZ5wXfyWtqmqLWVNYHbxLdCOelXF9OnyCzvG6X5CPLQsgU/wT3QQ=";
     const char * pExpectedExpiration = "2024-12-23T18:26:52Z";
 
-    result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage,
-                                                               messageLength,
-                                                               &( credentials ) );
+    result = Signaling_ParseFetchTempCredsResponseFromAwsIot( pMessage,
+                                                              messageLength,
+                                                              &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
@@ -1206,14 +1201,13 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse( void )
     TEST_ASSERT_EQUAL( strlen( pExpectedSessionToken ),
                        credentials.sessionTokenLength );
     TEST_ASSERT_EQUAL_STRING_LEN( pExpectedSessionToken,
-                                  credentials.sessionToken,
+                                  credentials.pSessionToken,
                                   credentials.sessionTokenLength );
     TEST_ASSERT_EQUAL( strlen( pExpectedExpiration ),
                        credentials.expirationLength );
     TEST_ASSERT_EQUAL_STRING_LEN( pExpectedExpiration,
-                                  credentials.expiration,
+                                  credentials.pExpiration,
                                   credentials.expirationLength );
-
 }
 
 /*-----------------------------------------------------------*/

--- a/test/unit-test/signaling_api/signaling_api_utest.c
+++ b/test/unit-test/signaling_api/signaling_api_utest.c
@@ -676,33 +676,41 @@ void test_signaling_ConstructFetchTemporaryCredentialRequest_BadParams( void )
     SignalingResult_t result;
 
 
-    result = Signaling_ConstructFetchTemporaryCredentialRequest( NULL, endpointLength,
-                                                                ( pRoleAlias ), roleAliasLength,
-                                                                &( requestBuffer ) );
+    result = Signaling_ConstructFetchTemporaryCredentialRequest( NULL,
+                                                                 endpointLength,
+                                                                 ( pRoleAlias ),
+                                                                 roleAliasLength,
+                                                                 &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
 
-    result = Signaling_ConstructFetchTemporaryCredentialRequest( ( pEndpoint ), endpointLength,
-                                                                NULL,  roleAliasLength,
-                                                                &( requestBuffer ) );
+    result = Signaling_ConstructFetchTemporaryCredentialRequest( ( pEndpoint ),
+                                                                 endpointLength,
+                                                                 NULL,
+                                                                 roleAliasLength,
+                                                                 &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
 
-    result = Signaling_ConstructFetchTemporaryCredentialRequest( ( pEndpoint ), endpointLength,
-                                                                ( pRoleAlias ), roleAliasLength,
-                                                                NULL );
+    result = Signaling_ConstructFetchTemporaryCredentialRequest( ( pEndpoint ),
+                                                                 endpointLength,
+                                                                 ( pRoleAlias ),
+                                                                 roleAliasLength,
+                                                                 NULL );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     requestBuffer.pUrl = NULL;
-    result = Signaling_ConstructFetchTemporaryCredentialRequest( ( pEndpoint ), endpointLength,
-                                                                ( pRoleAlias ), roleAliasLength,
-                                                                &( requestBuffer ) );
+    result = Signaling_ConstructFetchTemporaryCredentialRequest( ( pEndpoint ),
+                                                                 endpointLength,
+                                                                 ( pRoleAlias ),
+                                                                 roleAliasLength,
+                                                                 &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -727,9 +735,11 @@ void test_signaling_ConstructFetchTemporaryCredentialRequest_UrlOutOfMemory( voi
     requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
 
-    result = Signaling_ConstructFetchTemporaryCredentialRequest( ( pEndpoint ), endpointLength,
-                                                                ( pRoleAlias ), roleAliasLength,
-                                                                &( requestBuffer ) );
+    result = Signaling_ConstructFetchTemporaryCredentialRequest( ( pEndpoint ),
+                                                                 endpointLength,
+                                                                 ( pRoleAlias ),
+                                                                 roleAliasLength,
+                                                                 &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OUT_OF_MEMORY,
                        result );
@@ -754,9 +764,11 @@ void test_signaling_ConstructFetchTemporaryCredentialRequest( void )
     requestBuffer.pUrl = &( urlBuffer[ 0 ] );
     requestBuffer.urlLength = sizeof( urlBuffer );
 
-    result = Signaling_ConstructFetchTemporaryCredentialRequest( ( pEndpoint ), endpointLength,
-                                                                ( pRoleAlias ), roleAliasLength,
-                                                                &( requestBuffer ) );
+    result = Signaling_ConstructFetchTemporaryCredentialRequest( ( pEndpoint ),
+                                                                 endpointLength,
+                                                                 ( pRoleAlias ),
+                                                                 roleAliasLength,
+                                                                 &( requestBuffer ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );
@@ -780,15 +792,15 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_BadParams( void )
     size_t messageLength = strlen( pMessage );
 
     result = Signaling_ParseFetchTemporaryCredentialsResponse( NULL,
-                                                             messageLength,
-                                                             &( credentials ) );
+                                                               messageLength,
+                                                               &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
     result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage,
-                                                             messageLength,
-                                                             NULL );
+                                                               messageLength,
+                                                               NULL );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
@@ -807,8 +819,8 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_InvalidJson( void )
     size_t messageLength = sizeof( pMessage );
 
     result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage,
-                                                             messageLength,
-                                                             &( credentials ) );
+                                                               messageLength,
+                                                               &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
                        result );
@@ -819,8 +831,8 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_InvalidJson( void )
     size_t messageLength2 = strlen( pMessage2 );
 
     result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage2,
-                                                             messageLength2,
-                                                             &( credentials ) );
+                                                               messageLength2,
+                                                               &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_INVALID_JSON,
                        result );
@@ -847,8 +859,8 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_UnexpectedResponse( v
     size_t messageLength = strlen( pMessage );
 
     result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage,
-                                                             messageLength,
-                                                             &( credentials ) );
+                                                               messageLength,
+                                                               &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
@@ -865,8 +877,8 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_UnexpectedResponse( v
     size_t messageLength2 = strlen( pMessage2 );
 
     result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage2,
-                                                             messageLength2,
-                                                             &( credentials ) );
+                                                               messageLength2,
+                                                               &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
@@ -880,8 +892,8 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_UnexpectedResponse( v
     size_t messageLength3 = strlen( pMessage3 );
 
     result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage3,
-                                                             messageLength3,
-                                                             &( credentials ) );
+                                                               messageLength3,
+                                                               &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
@@ -916,8 +928,8 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_AccessKeyTooLong( voi
     size_t messageLength = strlen( message );
 
     result = Signaling_ParseFetchTemporaryCredentialsResponse( &( message[ 0 ] ),
-                                                             messageLength,
-                                                             &( credentials ) );
+                                                               messageLength,
+                                                               &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_ACCESS_KEY_LENGTH_TOO_LARGE,
                        result );
@@ -953,8 +965,8 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_SecretAccessKeyTooLon
     size_t messageLength = strlen( message );
 
     result = Signaling_ParseFetchTemporaryCredentialsResponse( &( message[ 0 ] ),
-                                                             messageLength,
-                                                             &( credentials ) );
+                                                               messageLength,
+                                                               &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_SECRET_ACCESS_KEY_LENGTH_TOO_LARGE,
                        result );
@@ -991,8 +1003,8 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_SessionTokenTooLong( 
     size_t messageLength = strlen( message );
 
     result = Signaling_ParseFetchTemporaryCredentialsResponse( &( message[ 0 ] ),
-                                                             messageLength,
-                                                             &( credentials ) );
+                                                               messageLength,
+                                                               &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_SESSION_TOKEN_LENGTH_TOO_LARGE,
                        result );
@@ -1030,8 +1042,8 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_ExpirationTooLong( vo
     size_t messageLength = strlen( message );
 
     result = Signaling_ParseFetchTemporaryCredentialsResponse( &( message[ 0 ] ),
-                                                             messageLength,
-                                                             &( credentials ) );
+                                                               messageLength,
+                                                               &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_EXPIRATION_LENGTH_TOO_LARGE,
                        result );
@@ -1058,8 +1070,8 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_NoAccessKey( void )
     "}";
     size_t messageLength = strlen( pMessage );
     result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage,
-                                                             messageLength,
-                                                             &( credentials ) );
+                                                               messageLength,
+                                                               &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
@@ -1086,8 +1098,8 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_NoSecretAccessKey( vo
     "}";
     size_t messageLength = strlen( pMessage );
     result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage,
-                                                             messageLength,
-                                                             &( credentials ) );
+                                                               messageLength,
+                                                               &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
@@ -1114,8 +1126,8 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_NoSessionToken( void 
     "}";
     size_t messageLength = strlen( pMessage );
     result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage,
-                                                             messageLength,
-                                                             &( credentials ) );
+                                                               messageLength,
+                                                               &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
@@ -1142,8 +1154,8 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse_NoExpiration( void )
     "}";
     size_t messageLength = strlen( pMessage );
     result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage,
-                                                             messageLength,
-                                                             &( credentials ) );
+                                                               messageLength,
+                                                               &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_UNEXPECTED_RESPONSE,
                        result );
@@ -1176,8 +1188,8 @@ void test_signaling_ParseFetchTemporaryCredentialsResponse( void )
     const char * pExpectedExpiration = "2024-12-23T18:26:52Z";
 
     result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage,
-                                                             messageLength,
-                                                             &( credentials ) );
+                                                               messageLength,
+                                                               &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
                        result );

--- a/test/unit-test/signaling_api/signaling_api_utest.c
+++ b/test/unit-test/signaling_api/signaling_api_utest.c
@@ -772,21 +772,21 @@ void test_signaling_ConstructFetchTemporaryCredentialRequest( void )
 /**
  * @brief Validate Signaling Parse Session Token Credentials fail functionality for Bad Parameters.
  */
-void test_signaling_ParseTemporaryCredentialsResponse_BadParams( void )
+void test_signaling_ParseFetchTemporaryCredentialsResponse_BadParams( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
     const char * pMessage = "Valid-Message";
     size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseTemporaryCredentialsResponse( NULL,
+    result = Signaling_ParseFetchTemporaryCredentialsResponse( NULL,
                                                              messageLength,
                                                              &( credentials ) );
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
 
-    result = Signaling_ParseTemporaryCredentialsResponse( pMessage,
+    result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage,
                                                              messageLength,
                                                              NULL );
 
@@ -799,14 +799,14 @@ void test_signaling_ParseTemporaryCredentialsResponse_BadParams( void )
 /**
  * @brief Validate Signaling Parse Session Token Credentials functionality.
  */
-void test_signaling_ParseTemporaryCredentialsResponse_InvalidJson( void )
+void test_signaling_ParseFetchTemporaryCredentialsResponse_InvalidJson( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
     const char * pMessage = "{\"credentials\": {";  /* Missing closing brace. */
     size_t messageLength = sizeof( pMessage );
 
-    result = Signaling_ParseTemporaryCredentialsResponse( pMessage,
+    result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage,
                                                              messageLength,
                                                              &( credentials ) );
 
@@ -818,7 +818,7 @@ void test_signaling_ParseTemporaryCredentialsResponse_InvalidJson( void )
     const char * pMessage2 = "{}"; /* Empty JSON. */
     size_t messageLength2 = strlen( pMessage2 );
 
-    result = Signaling_ParseTemporaryCredentialsResponse( pMessage2,
+    result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage2,
                                                              messageLength2,
                                                              &( credentials ) );
 
@@ -831,7 +831,7 @@ void test_signaling_ParseTemporaryCredentialsResponse_InvalidJson( void )
 /**
  * @brief Validate Signaling Parse Describe Response functionality for Unexpected Response.
  */
-void test_signaling_ParseTemporaryCredentialsResponse_UnexpectedResponse( void )
+void test_signaling_ParseFetchTemporaryCredentialsResponse_UnexpectedResponse( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
@@ -846,7 +846,7 @@ void test_signaling_ParseTemporaryCredentialsResponse_UnexpectedResponse( void )
     "}";
     size_t messageLength = strlen( pMessage );
 
-    result = Signaling_ParseTemporaryCredentialsResponse( pMessage,
+    result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage,
                                                              messageLength,
                                                              &( credentials ) );
 
@@ -864,7 +864,7 @@ void test_signaling_ParseTemporaryCredentialsResponse_UnexpectedResponse( void )
     "}";
     size_t messageLength2 = strlen( pMessage2 );
 
-    result = Signaling_ParseTemporaryCredentialsResponse( pMessage2,
+    result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage2,
                                                              messageLength2,
                                                              &( credentials ) );
 
@@ -879,7 +879,7 @@ void test_signaling_ParseTemporaryCredentialsResponse_UnexpectedResponse( void )
     "}";
     size_t messageLength3 = strlen( pMessage3 );
 
-    result = Signaling_ParseTemporaryCredentialsResponse( pMessage3,
+    result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage3,
                                                              messageLength3,
                                                              &( credentials ) );
 
@@ -892,7 +892,7 @@ void test_signaling_ParseTemporaryCredentialsResponse_UnexpectedResponse( void )
 /**
  * @brief Validate Signaling Parse Session Token Response functionality for too long Access Key.
  */
-void test_signaling_ParseTemporaryCredentialsResponse_AccessKeyTooLong( void )
+void test_signaling_ParseFetchTemporaryCredentialsResponse_AccessKeyTooLong( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
@@ -915,7 +915,7 @@ void test_signaling_ParseTemporaryCredentialsResponse_AccessKeyTooLong( void )
                longAccessKey );
     size_t messageLength = strlen( message );
 
-    result = Signaling_ParseTemporaryCredentialsResponse( &( message[ 0 ] ),
+    result = Signaling_ParseFetchTemporaryCredentialsResponse( &( message[ 0 ] ),
                                                              messageLength,
                                                              &( credentials ) );
 
@@ -928,7 +928,7 @@ void test_signaling_ParseTemporaryCredentialsResponse_AccessKeyTooLong( void )
 /**
  * @brief Validate Signaling Parse Session Token Response functionality for too long Secret Access Key.
  */
-void test_signaling_ParseTemporaryCredentialsResponse_SecretAccessKeyTooLong( void )
+void test_signaling_ParseFetchTemporaryCredentialsResponse_SecretAccessKeyTooLong( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
@@ -952,7 +952,7 @@ void test_signaling_ParseTemporaryCredentialsResponse_SecretAccessKeyTooLong( vo
                longSecretAccessKey );
     size_t messageLength = strlen( message );
 
-    result = Signaling_ParseTemporaryCredentialsResponse( &( message[ 0 ] ),
+    result = Signaling_ParseFetchTemporaryCredentialsResponse( &( message[ 0 ] ),
                                                              messageLength,
                                                              &( credentials ) );
 
@@ -965,7 +965,7 @@ void test_signaling_ParseTemporaryCredentialsResponse_SecretAccessKeyTooLong( vo
 /**
  * @brief Validate Signaling Parse Session Token Response functionality for too long Session Token.
  */
-void test_signaling_ParseTemporaryCredentialsResponse_SessionTokenTooLong( void )
+void test_signaling_ParseFetchTemporaryCredentialsResponse_SessionTokenTooLong( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
@@ -990,7 +990,7 @@ void test_signaling_ParseTemporaryCredentialsResponse_SessionTokenTooLong( void 
                longSessionToken );
     size_t messageLength = strlen( message );
 
-    result = Signaling_ParseTemporaryCredentialsResponse( &( message[ 0 ] ),
+    result = Signaling_ParseFetchTemporaryCredentialsResponse( &( message[ 0 ] ),
                                                              messageLength,
                                                              &( credentials ) );
 
@@ -1003,7 +1003,7 @@ void test_signaling_ParseTemporaryCredentialsResponse_SessionTokenTooLong( void 
 /**
  * @brief Validate Signaling Parse Session Token Response functionality for too long Expiration.
  */
-void test_signaling_ParseTemporaryCredentialsResponse_ExpirationTooLong( void )
+void test_signaling_ParseFetchTemporaryCredentialsResponse_ExpirationTooLong( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
@@ -1029,7 +1029,7 @@ void test_signaling_ParseTemporaryCredentialsResponse_ExpirationTooLong( void )
                longExpiration );
     size_t messageLength = strlen( message );
 
-    result = Signaling_ParseTemporaryCredentialsResponse( &( message[ 0 ] ),
+    result = Signaling_ParseFetchTemporaryCredentialsResponse( &( message[ 0 ] ),
                                                              messageLength,
                                                              &( credentials ) );
 
@@ -1042,7 +1042,7 @@ void test_signaling_ParseTemporaryCredentialsResponse_ExpirationTooLong( void )
 /**
  * @brief Validate Signaling Parse Temporary Credential Response functionality.
  */
-void test_signaling_ParseTemporaryCredentialsResponse_NoAccessKey( void )
+void test_signaling_ParseFetchTemporaryCredentialsResponse_NoAccessKey( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
@@ -1057,7 +1057,7 @@ void test_signaling_ParseTemporaryCredentialsResponse_NoAccessKey( void )
         "}"
     "}";
     size_t messageLength = strlen( pMessage );
-    result = Signaling_ParseTemporaryCredentialsResponse( pMessage,
+    result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage,
                                                              messageLength,
                                                              &( credentials ) );
 
@@ -1070,7 +1070,7 @@ void test_signaling_ParseTemporaryCredentialsResponse_NoAccessKey( void )
 /**
  * @brief Validate Signaling Parse Temporary Credential Response functionality.
  */
-void test_signaling_ParseTemporaryCredentialsResponse_NoSecretAccessKey( void )
+void test_signaling_ParseFetchTemporaryCredentialsResponse_NoSecretAccessKey( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
@@ -1085,7 +1085,7 @@ void test_signaling_ParseTemporaryCredentialsResponse_NoSecretAccessKey( void )
         "}"
     "}";
     size_t messageLength = strlen( pMessage );
-    result = Signaling_ParseTemporaryCredentialsResponse( pMessage,
+    result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage,
                                                              messageLength,
                                                              &( credentials ) );
 
@@ -1098,7 +1098,7 @@ void test_signaling_ParseTemporaryCredentialsResponse_NoSecretAccessKey( void )
 /**
  * @brief Validate Signaling Parse Temporary Credential Response functionality.
  */
-void test_signaling_ParseTemporaryCredentialsResponse_NoSessionToken( void )
+void test_signaling_ParseFetchTemporaryCredentialsResponse_NoSessionToken( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
@@ -1113,7 +1113,7 @@ void test_signaling_ParseTemporaryCredentialsResponse_NoSessionToken( void )
         "}"
     "}";
     size_t messageLength = strlen( pMessage );
-    result = Signaling_ParseTemporaryCredentialsResponse( pMessage,
+    result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage,
                                                              messageLength,
                                                              &( credentials ) );
 
@@ -1126,7 +1126,7 @@ void test_signaling_ParseTemporaryCredentialsResponse_NoSessionToken( void )
 /**
  * @brief Validate Signaling Parse Temporary Credential Response functionality.
  */
-void test_signaling_ParseTemporaryCredentialsResponse_NoExpiration( void )
+void test_signaling_ParseFetchTemporaryCredentialsResponse_NoExpiration( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
@@ -1141,7 +1141,7 @@ void test_signaling_ParseTemporaryCredentialsResponse_NoExpiration( void )
         "}"
     "}";
     size_t messageLength = strlen( pMessage );
-    result = Signaling_ParseTemporaryCredentialsResponse( pMessage,
+    result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage,
                                                              messageLength,
                                                              &( credentials ) );
 
@@ -1154,7 +1154,7 @@ void test_signaling_ParseTemporaryCredentialsResponse_NoExpiration( void )
 /**
  * @brief Validate Signaling Parse Temporary Credential Response functionality.
  */
-void test_signaling_ParseTemporaryCredentialsResponse( void )
+void test_signaling_ParseFetchTemporaryCredentialsResponse( void )
 {
     SignalingCredential_t credentials;
     SignalingResult_t result;
@@ -1175,7 +1175,7 @@ void test_signaling_ParseTemporaryCredentialsResponse( void )
     const char * pExpectedSessionToken = "IQoJb3JpZ2luX3TT5KsgDCNv//////////wEQABoM4L2LJKaRl/zI1I+48vpNn40TZ5wXfyWtqmqLWVNYHbxLdCOelXF9OnyCzvG6X5CPLQsgU/wT3QQ=";
     const char * pExpectedExpiration = "2024-12-23T18:26:52Z";
 
-    result = Signaling_ParseTemporaryCredentialsResponse( pMessage,
+    result = Signaling_ParseFetchTemporaryCredentialsResponse( pMessage,
                                                              messageLength,
                                                              &( credentials ) );
 


### PR DESCRIPTION
### Description of changes:

This PR is for adding Session Token Credentials URL Request creation and Response Parsing implementation and its Unit-Tests.


### Test Steps

```
cmake -S test/unit-test -B build/ -G "Unix Makefiles"  -DBUILD_CLONE_SUBMODULES=ON -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
make -C build all
cd build
ctest -E system --output-on-failure
make coverage
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
