### PR TITLE
Generalizing TTL Seconds to architecture  independent environment

### DIFF
--- a/source/signaling_api.c
+++ b/source/signaling_api.c
@@ -837,7 +837,7 @@ SignalingResult_t Signaling_ConstructCreateSignalingChannelRequest( SignalingAws
                                    ( int ) pCreateSignalingChannelRequestInfo->channelName.channelNameLength,
                                    pCreateSignalingChannelRequestInfo->channelName.pChannelName,
                                    ( pCreateSignalingChannelRequestInfo->channelType == SIGNALING_TYPE_CHANNEL_SINGLE_MASTER ) ? "SINGLE_MASTER" : "UNKOWN",
-                                   pCreateSignalingChannelRequestInfo->messageTtlSeconds );
+                                   ( unsigned int ) pCreateSignalingChannelRequestInfo->messageTtlSeconds );
 
         result = InterpretSnprintfReturnValue( snprintfRetVal, remainingLength );
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The PR is for generalising an `snprintf()` to have an input parameter type as architecture independent application. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
