### PR TITLE
JoinStorageSession changes

### DIFF
--- a/source/signaling_api.c
+++ b/source/signaling_api.c
@@ -1600,7 +1600,8 @@ SignalingResult_t Signaling_ConstructWssMessage( WssSendMessage_t * pWssSendMess
     if( ( pWssSendMessage == NULL ) ||
         ( pBuffer == NULL ) ||
         ( pWssSendMessage->pBase64EncodedMessage == NULL ) ||
-        ( pWssSendMessage->pRecipientClientId == NULL ) )
+        ( pWssSendMessage->messageType != SIGNALING_TYPE_MESSAGE_SDP_ANSWER && 
+          pWssSendMessage->pRecipientClientId == NULL ) )
     {
         result = SIGNALING_RESULT_BAD_PARAM;
     }

--- a/source/signaling_api.c
+++ b/source/signaling_api.c
@@ -1600,8 +1600,8 @@ SignalingResult_t Signaling_ConstructWssMessage( WssSendMessage_t * pWssSendMess
     if( ( pWssSendMessage == NULL ) ||
         ( pBuffer == NULL ) ||
         ( pWssSendMessage->pBase64EncodedMessage == NULL ) ||
-        ( pWssSendMessage->messageType != SIGNALING_TYPE_MESSAGE_SDP_ANSWER && 
-          pWssSendMessage->pRecipientClientId == NULL ) )
+        ( ( pWssSendMessage->messageType != SIGNALING_TYPE_MESSAGE_SDP_ANSWER ) && 
+          ( pWssSendMessage->pRecipientClientId == NULL ) ) )
     {
         result = SIGNALING_RESULT_BAD_PARAM;
     }

--- a/source/signaling_api.c
+++ b/source/signaling_api.c
@@ -1600,7 +1600,7 @@ SignalingResult_t Signaling_ConstructWssMessage( WssSendMessage_t * pWssSendMess
     if( ( pWssSendMessage == NULL ) ||
         ( pBuffer == NULL ) ||
         ( pWssSendMessage->pBase64EncodedMessage == NULL ) ||
-        ( ( pWssSendMessage->messageType != SIGNALING_TYPE_MESSAGE_SDP_ANSWER ) && 
+        ( ( pWssSendMessage->recipientClientIdLength != 0 ) && 
           ( pWssSendMessage->pRecipientClientId == NULL ) ) )
     {
         result = SIGNALING_RESULT_BAD_PARAM;

--- a/test/unit-test/signaling_api/signaling_api_utest.c
+++ b/test/unit-test/signaling_api/signaling_api_utest.c
@@ -4597,6 +4597,7 @@ void test_signaling_ConstructWssMessage_BadParams( void )
     wssSendMessage.pBase64EncodedMessage = "TestMessage";
     wssSendMessage.base64EncodedMessageLength = strlen( wssSendMessage.pBase64EncodedMessage );
     wssSendMessage.pRecipientClientId = NULL;
+    wssSendMessage.recipientClientIdLength = 100;
 
     result = Signaling_ConstructWssMessage( &( wssSendMessage ),
                                             &( messageBuffer[ 0 ] ),
@@ -4604,6 +4605,46 @@ void test_signaling_ConstructWssMessage_BadParams( void )
 
     TEST_ASSERT_EQUAL( SIGNALING_RESULT_BAD_PARAM,
                        result );
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Validate Signaling Construct Web-Socket Message functionality for Null Client ID and Zero Client Length.
+ */
+void test_signaling_ConstructWssMessage_NullClientID_ZeroClientLength( void )
+{
+    WssSendMessage_t wssSendMessage = { 0 };
+    SignalingResult_t result;
+    char messageBuffer[ 300 ];
+    size_t messageBufferLength = sizeof( messageBuffer );
+    const char * pExpectedMessage = 
+    "{"
+        "\"action\":\"ICE_CANDIDATE\","
+        "\"RecipientClientId\":\"\","
+        "\"MessagePayload\":\"base64encodedmessage\","
+        "\"CorrelationId\":\"TestCorrelationId\""
+    "}";
+   
+    wssSendMessage.messageType = SIGNALING_TYPE_MESSAGE_ICE_CANDIDATE;
+    wssSendMessage.pBase64EncodedMessage = "base64encodedmessage";
+    wssSendMessage.base64EncodedMessageLength = strlen( wssSendMessage.pBase64EncodedMessage );
+    wssSendMessage.pRecipientClientId = NULL;
+    wssSendMessage.recipientClientIdLength = 0;
+    wssSendMessage.pCorrelationId = "TestCorrelationId";
+    wssSendMessage.correlationIdLength = strlen( wssSendMessage.pCorrelationId );
+    
+    result = Signaling_ConstructWssMessage( &( wssSendMessage ),
+                                            &( messageBuffer[ 0 ] ),
+                                            &( messageBufferLength ) );
+
+    TEST_ASSERT_EQUAL( SIGNALING_RESULT_OK,
+                       result );
+    TEST_ASSERT_EQUAL( strlen( pExpectedMessage ),
+                       messageBufferLength );
+    TEST_ASSERT_EQUAL_STRING_LEN( pExpectedMessage,
+                                  &( messageBuffer [ 0 ] ),
+                                  messageBufferLength );
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
### Description of changes:
Modified parameter validation to allow NULL ClientID specifically for SDP Answer messages during JoinStorageSession operations. This change addresses a use case where recipient client ID is NOT required for storage session joins.

### Test Steps:
Refer `README.md`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
